### PR TITLE
feat: response time tracking, route detail panel, and keyboard navigation

### DIFF
--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -90,27 +90,27 @@ func (c *Checker) checkAll() {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			status := c.check(r.URL)
+			status, elapsed := c.check(r.URL)
 			now := time.Now()
-			c.store.UpdateHealth(r.ID, status, now)
+			c.store.UpdateHealth(r.ID, status, now, elapsed.Milliseconds())
 		}(route)
 	}
 
 	wg.Wait()
 }
 
-func (c *Checker) check(url string) model.HealthStatus {
+func (c *Checker) check(url string) (model.HealthStatus, time.Duration) {
 	start := time.Now()
 
 	req, err := http.NewRequest(http.MethodHead, url, nil)
 	if err != nil {
-		return model.HealthUnhealthy
+		return model.HealthUnhealthy, 0
 	}
 	req.Header.Set("User-Agent", "RouteBoard-HealthCheck/1.0")
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return model.HealthUnhealthy
+		return model.HealthUnhealthy, 0
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -120,12 +120,12 @@ func (c *Checker) check(url string) model.HealthStatus {
 	switch {
 	case resp.StatusCode >= 200 && resp.StatusCode < 400:
 		if elapsed > degradedThreshold {
-			return model.HealthDegraded
+			return model.HealthDegraded, elapsed
 		}
-		return model.HealthHealthy
+		return model.HealthHealthy, elapsed
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
-		return model.HealthDegraded
+		return model.HealthDegraded, elapsed
 	default:
-		return model.HealthUnhealthy
+		return model.HealthUnhealthy, elapsed
 	}
 }

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -29,9 +29,12 @@ func TestCheckHealthy(t *testing.T) {
 	s := store.New(nil)
 	checker := NewChecker(cfg, s)
 
-	status := checker.check(srv.URL)
+	status, elapsed := checker.check(srv.URL)
 	if status != model.HealthHealthy {
 		t.Errorf("got %q, want %q", status, model.HealthHealthy)
+	}
+	if elapsed <= 0 {
+		t.Error("expected elapsed > 0 for healthy check")
 	}
 }
 
@@ -43,9 +46,12 @@ func TestCheckUnhealthy500(t *testing.T) {
 
 	checker := NewChecker(testConfig(), store.New(nil))
 
-	status := checker.check(srv.URL)
+	status, elapsed := checker.check(srv.URL)
 	if status != model.HealthUnhealthy {
 		t.Errorf("got %q, want %q", status, model.HealthUnhealthy)
+	}
+	if elapsed <= 0 {
+		t.Error("expected elapsed > 0 for server response")
 	}
 }
 
@@ -57,18 +63,24 @@ func TestCheckDegraded4xx(t *testing.T) {
 
 	checker := NewChecker(testConfig(), store.New(nil))
 
-	status := checker.check(srv.URL)
+	status, elapsed := checker.check(srv.URL)
 	if status != model.HealthDegraded {
 		t.Errorf("got %q, want %q", status, model.HealthDegraded)
+	}
+	if elapsed <= 0 {
+		t.Error("expected elapsed > 0 for server response")
 	}
 }
 
 func TestCheckUnhealthyConnectionRefused(t *testing.T) {
 	checker := NewChecker(testConfig(), store.New(nil))
 
-	status := checker.check("http://localhost:1") // nothing listening
+	status, elapsed := checker.check("http://localhost:1") // nothing listening
 	if status != model.HealthUnhealthy {
 		t.Errorf("got %q, want %q", status, model.HealthUnhealthy)
+	}
+	if elapsed != 0 {
+		t.Errorf("expected elapsed == 0 for connection error, got %v", elapsed)
 	}
 }
 
@@ -83,9 +95,12 @@ func TestCheckHealthyRedirect(t *testing.T) {
 
 	checker := NewChecker(testConfig(), store.New(nil))
 
-	status := checker.check(redirect.URL)
+	status, elapsed := checker.check(redirect.URL)
 	if status != model.HealthHealthy {
 		t.Errorf("got %q, want %q", status, model.HealthHealthy)
+	}
+	if elapsed <= 0 {
+		t.Error("expected elapsed > 0 for healthy redirect")
 	}
 }
 
@@ -108,6 +123,12 @@ func TestCheckAllUpdatesStore(t *testing.T) {
 	}
 	if route.HealthCheckedAt.IsZero() {
 		t.Error("HealthCheckedAt should be set")
+	}
+	if route.ResponseTimeMs < 0 {
+		t.Error("expected ResponseTimeMs >= 0 after health check")
+	}
+	if len(route.ResponseTimeHistory) != 1 {
+		t.Errorf("expected 1 response time history entry, got %d", len(route.ResponseTimeHistory))
 	}
 
 	// Should have received a health change event

--- a/internal/model/route.go
+++ b/internal/model/route.go
@@ -31,9 +31,11 @@ type Route struct {
 	CreatedAt   time.Time         `json:"createdAt"`
 	UpdatedAt   time.Time         `json:"updatedAt"`
 
-	Health          HealthStatus   `json:"health"`
-	HealthCheckedAt time.Time      `json:"healthCheckedAt,omitempty"`
-	HealthHistory   []HealthStatus `json:"healthHistory,omitempty"`
+	Health              HealthStatus   `json:"health"`
+	HealthCheckedAt     time.Time      `json:"healthCheckedAt,omitempty"`
+	HealthHistory       []HealthStatus `json:"healthHistory,omitempty"`
+	ResponseTimeMs      int64          `json:"responseTimeMs,omitempty"`
+	ResponseTimeHistory []int64        `json:"responseTimeHistory,omitempty"`
 }
 
 const HealthHistoryMax = 60

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -106,7 +106,7 @@ func (s *Store) List() []*model.Route {
 	return routes
 }
 
-func (s *Store) UpdateHealth(id string, status model.HealthStatus, checkedAt time.Time) {
+func (s *Store) UpdateHealth(id string, status model.HealthStatus, checkedAt time.Time, responseTimeMs int64) {
 	s.mu.Lock()
 	route, exists := s.routes[id]
 	var previousHealth model.HealthStatus
@@ -114,10 +114,16 @@ func (s *Store) UpdateHealth(id string, status model.HealthStatus, checkedAt tim
 		previousHealth = route.Health
 		route.Health = status
 		route.HealthCheckedAt = checkedAt
-		// Append to history ring buffer
+		route.ResponseTimeMs = responseTimeMs
+		// Append to health history ring buffer
 		route.HealthHistory = append(route.HealthHistory, status)
 		if len(route.HealthHistory) > model.HealthHistoryMax {
 			route.HealthHistory = route.HealthHistory[len(route.HealthHistory)-model.HealthHistoryMax:]
+		}
+		// Append to response time history ring buffer
+		route.ResponseTimeHistory = append(route.ResponseTimeHistory, responseTimeMs)
+		if len(route.ResponseTimeHistory) > model.HealthHistoryMax {
+			route.ResponseTimeHistory = route.ResponseTimeHistory[len(route.ResponseTimeHistory)-model.HealthHistoryMax:]
 		}
 	}
 	s.mu.Unlock()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -172,6 +172,37 @@ func TestStoreNamespaces(t *testing.T) {
 	}
 }
 
+func TestStoreUpdateHealthResponseTime(t *testing.T) {
+	s := New(nil)
+	s.Set(newRoute("r1", "App", "default", 0))
+
+	s.UpdateHealth("r1", model.HealthHealthy, time.Now(), 42)
+
+	r, _ := s.Get("r1")
+	if r.ResponseTimeMs != 42 {
+		t.Errorf("got ResponseTimeMs %d, want 42", r.ResponseTimeMs)
+	}
+	if len(r.ResponseTimeHistory) != 1 || r.ResponseTimeHistory[0] != 42 {
+		t.Errorf("got ResponseTimeHistory %v, want [42]", r.ResponseTimeHistory)
+	}
+
+	// Fill beyond max to test ring buffer (already have 1 entry from above)
+	for i := range model.HealthHistoryMax + 5 {
+		s.UpdateHealth("r1", model.HealthHealthy, time.Now(), int64(i))
+	}
+
+	r, _ = s.Get("r1")
+	if len(r.ResponseTimeHistory) != model.HealthHistoryMax {
+		t.Errorf("got %d history entries, want %d", len(r.ResponseTimeHistory), model.HealthHistoryMax)
+	}
+	// Total entries inserted: 1 (42) + HealthHistoryMax+5 = HealthHistoryMax+6
+	// After capping to HealthHistoryMax, oldest 6 are dropped: 42, 0, 1, 2, 3, 4
+	// So first remaining = 5
+	if r.ResponseTimeHistory[0] != 5 {
+		t.Errorf("oldest entry = %d, want 5", r.ResponseTimeHistory[0])
+	}
+}
+
 func TestStoreGroupedRoutes(t *testing.T) {
 	s := New(nil)
 	s.Set(newRoute("r1", "A", "infra", 0))

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,52 +1,113 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CommandPalette } from "./components/CommandPalette";
 import { EmptyState } from "./components/EmptyState";
 import { Layout } from "./components/Layout";
+import { RouteDetailPanel } from "./components/RouteDetailPanel";
 import { RouteGrid } from "./components/RouteGrid";
 import { SkeletonGrid } from "./components/Skeleton";
 import { useFavorites } from "./hooks/useFavorites";
+import { useKeyboardNav } from "./hooks/useKeyboardNav";
 import { useRoutes } from "./hooks/useRoutes";
+import { useTheme } from "./hooks/useTheme";
 
 function App() {
 	const { routes, allRoutes, groupedRoutes, config, loading, connected, search, setSearch, namespace, setNamespace, healthFilter, setHealthFilter } =
 		useRoutes();
 
 	const { favorites, toggle, isFavorite } = useFavorites();
+	const { dark, toggle: toggleTheme } = useTheme();
 	const [view, setView] = useState<"grid" | "list">("grid");
+	const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
+	const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+	const searchInputRef = useRef<HTMLInputElement>(null);
+
+	const selectedRoute = selectedRouteId ? (allRoutes.find((r) => r.id === selectedRouteId) ?? null) : null;
+
+	const handleSelectRoute = useCallback((id: string) => setSelectedRouteId(id), []);
+
+	const { focusedRouteId } = useKeyboardNav({
+		routes,
+		disabled: !!selectedRoute || commandPaletteOpen,
+		searchInputRef,
+		onSelectRoute: handleSelectRoute,
+		onToggleFavorite: toggle,
+	});
+
+	// Cmd+K / Ctrl+K to toggle command palette
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+				e.preventDefault();
+				setCommandPaletteOpen((open) => !open);
+			}
+		};
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, []);
 
 	const hasRoutes = Object.keys(groupedRoutes).length > 0;
 	const isSearching = search !== "" || namespace !== "" || healthFilter !== "";
 
 	return (
-		<Layout
-			title={config.title}
-			connected={connected}
-			routeCount={routes.length}
-			namespaces={config.namespaces}
-			allRoutes={allRoutes}
-			search={search}
-			onSearchChange={setSearch}
-			namespace={namespace}
-			onNamespaceChange={setNamespace}
-			healthFilter={healthFilter}
-			onHealthFilterChange={setHealthFilter}
-			view={view}
-			onViewChange={setView}
-		>
-			{loading ? (
-				<SkeletonGrid />
-			) : hasRoutes ? (
-				<RouteGrid
-					groupedRoutes={groupedRoutes}
-					view={view}
-					allRoutes={allRoutes}
-					isFavorite={isFavorite}
+		<>
+			<Layout
+				title={config.title}
+				connected={connected}
+				routeCount={routes.length}
+				namespaces={config.namespaces}
+				allRoutes={allRoutes}
+				search={search}
+				onSearchChange={setSearch}
+				namespace={namespace}
+				onNamespaceChange={setNamespace}
+				healthFilter={healthFilter}
+				onHealthFilterChange={setHealthFilter}
+				view={view}
+				onViewChange={setView}
+				dark={dark}
+				onToggleTheme={toggleTheme}
+				searchInputRef={searchInputRef}
+				onOpenCommandPalette={() => setCommandPaletteOpen(true)}
+			>
+				{loading ? (
+					<SkeletonGrid />
+				) : hasRoutes ? (
+					<RouteGrid
+						groupedRoutes={groupedRoutes}
+						view={view}
+						allRoutes={allRoutes}
+						isFavorite={isFavorite}
+						onToggleFavorite={toggle}
+						favorites={favorites}
+						onSelectRoute={handleSelectRoute}
+						focusedRouteId={focusedRouteId}
+					/>
+				) : (
+					<EmptyState searching={isSearching} />
+				)}
+			</Layout>
+			{selectedRoute && (
+				<RouteDetailPanel
+					route={selectedRoute}
+					isFavorite={isFavorite(selectedRoute.id)}
 					onToggleFavorite={toggle}
-					favorites={favorites}
+					onClose={() => setSelectedRouteId(null)}
 				/>
-			) : (
-				<EmptyState searching={isSearching} />
 			)}
-		</Layout>
+			{commandPaletteOpen && (
+				<CommandPalette
+					routes={allRoutes}
+					dark={dark}
+					view={view}
+					onSelectRoute={handleSelectRoute}
+					onToggleTheme={toggleTheme}
+					onChangeView={setView}
+					onFilterNamespace={setNamespace}
+					onFilterHealth={setHealthFilter}
+					onClose={() => setCommandPaletteOpen(false)}
+				/>
+			)}
+		</>
 	);
 }
 

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,0 +1,246 @@
+import { Command, Grid3X3, List, Moon, Search, Sun, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Route } from "../types";
+import { ServiceIcon } from "./ServiceIcon";
+
+interface CommandPaletteProps {
+	routes: Route[];
+	dark: boolean;
+	view: "grid" | "list";
+	onSelectRoute: (id: string) => void;
+	onToggleTheme: () => void;
+	onChangeView: (view: "grid" | "list") => void;
+	onFilterNamespace: (ns: string) => void;
+	onFilterHealth: (h: string) => void;
+	onClose: () => void;
+}
+
+interface PaletteItem {
+	id: string;
+	label: string;
+	section: string;
+	icon?: React.ReactNode;
+	action: () => void;
+}
+
+export function CommandPalette({
+	routes,
+	dark,
+	view,
+	onSelectRoute,
+	onToggleTheme,
+	onChangeView,
+	onFilterNamespace,
+	onFilterHealth,
+	onClose,
+}: CommandPaletteProps) {
+	const [query, setQuery] = useState("");
+	const [selectedIndex, setSelectedIndex] = useState(0);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const listRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		inputRef.current?.focus();
+	}, []);
+
+	const items = useMemo<PaletteItem[]>(() => {
+		const all: PaletteItem[] = [];
+
+		// Routes
+		for (const r of routes) {
+			all.push({
+				id: `route:${r.id}`,
+				label: r.title,
+				section: "Routes",
+				icon: <ServiceIcon serviceName={r.serviceName} resourceName={r.name} size={16} />,
+				action: () => {
+					onSelectRoute(r.id);
+					onClose();
+				},
+			});
+		}
+
+		// Actions
+		all.push({
+			id: "action:theme",
+			label: dark ? "Switch to light mode" : "Switch to dark mode",
+			section: "Actions",
+			icon: dark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />,
+			action: () => {
+				onToggleTheme();
+				onClose();
+			},
+		});
+		all.push({
+			id: "action:view",
+			label: view === "grid" ? "Switch to list view" : "Switch to grid view",
+			section: "Actions",
+			icon: view === "grid" ? <List className="w-4 h-4" /> : <Grid3X3 className="w-4 h-4" />,
+			action: () => {
+				onChangeView(view === "grid" ? "list" : "grid");
+				onClose();
+			},
+		});
+		all.push({
+			id: "action:clear-filters",
+			label: "Clear all filters",
+			section: "Actions",
+			icon: <X className="w-4 h-4" />,
+			action: () => {
+				onFilterNamespace("");
+				onFilterHealth("");
+				onClose();
+			},
+		});
+
+		// Filters
+		const namespaces = [...new Set(routes.map((r) => r.namespace))].sort();
+		for (const ns of namespaces) {
+			all.push({
+				id: `filter:ns:${ns}`,
+				label: `Namespace: ${ns}`,
+				section: "Filters",
+				action: () => {
+					onFilterNamespace(ns);
+					onClose();
+				},
+			});
+		}
+		for (const h of ["healthy", "degraded", "unhealthy"]) {
+			all.push({
+				id: `filter:health:${h}`,
+				label: `Health: ${h}`,
+				section: "Filters",
+				action: () => {
+					onFilterHealth(h);
+					onClose();
+				},
+			});
+		}
+
+		return all;
+	}, [routes, dark, view, onSelectRoute, onToggleTheme, onChangeView, onFilterNamespace, onFilterHealth, onClose]);
+
+	const filtered = useMemo(() => {
+		if (!query) return items.slice(0, 15);
+		const q = query.toLowerCase();
+		return items.filter((item) => item.label.toLowerCase().includes(q)).slice(0, 15);
+	}, [items, query]);
+
+	// Reset selection on filter change
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset on filtered.length change
+	useEffect(() => {
+		setSelectedIndex(0);
+	}, [filtered.length]);
+
+	// Scroll selected into view
+	useEffect(() => {
+		const el = listRef.current?.children[selectedIndex] as HTMLElement | undefined;
+		el?.scrollIntoView({ block: "nearest" });
+	}, [selectedIndex]);
+
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			switch (e.key) {
+				case "ArrowDown":
+					e.preventDefault();
+					setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+					break;
+				case "ArrowUp":
+					e.preventDefault();
+					setSelectedIndex((i) => Math.max(i - 1, 0));
+					break;
+				case "Enter":
+					e.preventDefault();
+					filtered[selectedIndex]?.action();
+					break;
+				case "Escape":
+					e.preventDefault();
+					onClose();
+					break;
+			}
+		};
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [filtered, selectedIndex, onClose]);
+
+	// Group by section
+	const sections: { name: string; items: (PaletteItem & { globalIdx: number })[] }[] = [];
+	let idx = 0;
+	for (const item of filtered) {
+		const last = sections[sections.length - 1];
+		if (last && last.name === item.section) {
+			last.items.push({ ...item, globalIdx: idx });
+		} else {
+			sections.push({ name: item.section, items: [{ ...item, globalIdx: idx }] });
+		}
+		idx++;
+	}
+
+	return (
+		<>
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop overlay dismiss */}
+			<div role="presentation" className="fixed inset-0 z-[60] bg-deep/60 backdrop-blur-sm animate-overlay-fade-in" onClick={onClose} />
+			<div className="fixed inset-0 z-[60] flex items-start justify-center pt-[20vh] pointer-events-none">
+				<div className="pointer-events-auto w-[520px] max-w-[calc(100vw-2rem)] bg-card border border-line rounded-xl shadow-2xl overflow-hidden animate-card-enter">
+					{/* Search input */}
+					<div className="flex items-center gap-3 px-4 py-3 border-b border-line">
+						<Command className="w-4 h-4 text-tx3 flex-shrink-0" />
+						<input
+							ref={inputRef}
+							type="text"
+							value={query}
+							onChange={(e) => setQuery(e.target.value)}
+							placeholder="Type a command or search..."
+							className="flex-1 bg-transparent text-sm text-tx1 placeholder-tx3 outline-none font-body"
+						/>
+						{query && (
+							<button type="button" onClick={() => setQuery("")} className="text-tx3 hover:text-tx2 transition-colors">
+								<X className="w-4 h-4" />
+							</button>
+						)}
+					</div>
+
+					{/* Results */}
+					<div ref={listRef} className="max-h-[320px] overflow-y-auto py-2">
+						{filtered.length === 0 && <p className="px-4 py-6 text-center text-sm text-tx3">No results found</p>}
+						{sections.map((section) => (
+							<div key={section.name}>
+								<div className="px-4 py-1.5">
+									<span className="text-[10px] font-semibold uppercase tracking-wider text-tx3">{section.name}</span>
+								</div>
+								{section.items.map((item) => (
+									<button
+										key={item.id}
+										type="button"
+										onClick={item.action}
+										className={`w-full flex items-center gap-3 px-4 py-2 text-sm text-left transition-colors ${
+											item.globalIdx === selectedIndex ? "bg-accent/10 text-accent" : "text-tx1 hover:bg-elevated"
+										}`}
+									>
+										{item.icon && <span className="flex-shrink-0 text-tx2 w-5 h-5 flex items-center justify-center">{item.icon}</span>}
+										{!item.icon && <Search className="w-4 h-4 text-tx3 flex-shrink-0" />}
+										<span className="truncate">{item.label}</span>
+									</button>
+								))}
+							</div>
+						))}
+					</div>
+
+					{/* Footer hints */}
+					<div className="flex items-center gap-4 px-4 py-2 border-t border-line text-[10px] font-mono text-tx3">
+						<span>
+							<kbd className="px-1 py-0.5 rounded border border-line bg-elevated">↑↓</kbd> navigate
+						</span>
+						<span>
+							<kbd className="px-1 py-0.5 rounded border border-line bg-elevated">↵</kbd> select
+						</span>
+						<span>
+							<kbd className="px-1 py-0.5 rounded border border-line bg-elevated">esc</kbd> close
+						</span>
+					</div>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/web/src/components/HealthDot.tsx
+++ b/web/src/components/HealthDot.tsx
@@ -1,4 +1,5 @@
 import type { Route } from "../types";
+import { timeAgo } from "../utils/time";
 
 interface HealthDotProps {
 	health: Route["health"];
@@ -26,14 +27,4 @@ export function HealthDot({ health, checkedAt, size = "sm" }: HealthDotProps) {
 			<span className={`relative inline-block rounded-full ${dotSize} ${color}`} />
 		</span>
 	);
-}
-
-function timeAgo(dateStr: string): string {
-	const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
-	if (seconds < 10) return "just now";
-	if (seconds < 60) return `${seconds}s ago`;
-	const minutes = Math.floor(seconds / 60);
-	if (minutes < 60) return `${minutes}m ago`;
-	const hours = Math.floor(minutes / 60);
-	return `${hours}h ago`;
 }

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from "react";
+import { Command } from "lucide-react";
+import type { ReactNode, RefObject } from "react";
 import type { Route } from "../types";
 import { HealthFilter } from "./HealthFilter";
 import { NamespaceFilter } from "./NamespaceFilter";
@@ -20,6 +21,10 @@ interface LayoutProps {
 	onHealthFilterChange: (value: string) => void;
 	view: "grid" | "list";
 	onViewChange: (view: "grid" | "list") => void;
+	dark: boolean;
+	onToggleTheme: () => void;
+	searchInputRef: RefObject<HTMLInputElement | null>;
+	onOpenCommandPalette: () => void;
 	children: ReactNode;
 }
 
@@ -37,6 +42,10 @@ export function Layout({
 	onHealthFilterChange,
 	view,
 	onViewChange,
+	dark,
+	onToggleTheme,
+	searchInputRef,
+	onOpenCommandPalette,
 	children,
 }: LayoutProps) {
 	return (
@@ -63,18 +72,27 @@ export function Layout({
 						{/* Right: controls */}
 						<div className="flex items-center gap-2">
 							<div className="hidden sm:block w-64">
-								<SearchBar value={search} onChange={onSearchChange} />
+								<SearchBar ref={searchInputRef} value={search} onChange={onSearchChange} />
 							</div>
+							<button
+								type="button"
+								onClick={onOpenCommandPalette}
+								className="hidden sm:flex items-center gap-1.5 px-2 py-1.5 rounded-lg border border-line bg-surface text-tx3 hover:text-tx2 hover:border-line-hover transition-colors text-[11px] font-mono"
+								title="Command palette"
+							>
+								<Command className="w-3 h-3" />
+								<span>K</span>
+							</button>
 							<NamespaceFilter namespaces={namespaces} value={namespace} onChange={onNamespaceChange} />
 							<HealthFilter value={healthFilter} onChange={onHealthFilterChange} routes={allRoutes} />
 							<ViewToggle view={view} onChange={onViewChange} />
-							<ThemeToggle />
+							<ThemeToggle dark={dark} onToggle={onToggleTheme} />
 						</div>
 					</div>
 
 					{/* Mobile search */}
 					<div className="sm:hidden pb-3">
-						<SearchBar value={search} onChange={onSearchChange} />
+						<SearchBar ref={searchInputRef} value={search} onChange={onSearchChange} />
 					</div>
 				</div>
 			</header>

--- a/web/src/components/ResponseTimeSparkline.tsx
+++ b/web/src/components/ResponseTimeSparkline.tsx
@@ -1,0 +1,35 @@
+interface ResponseTimeSparklineProps {
+	history: number[];
+	width?: number;
+	height?: number;
+}
+
+export function ResponseTimeSparkline({ history, width = 200, height = 24 }: ResponseTimeSparklineProps) {
+	if (!history || history.length < 2) return null;
+
+	const max = Math.max(...history, 1);
+	const min = Math.min(...history);
+	const range = max - min || 1;
+
+	const padding = 1;
+	const chartH = height - padding * 2;
+	const step = width / (history.length - 1);
+
+	const points = history
+		.map((v, i) => {
+			const x = i * step;
+			const y = padding + chartH - ((v - min) / range) * chartH;
+			return `${x},${y}`;
+		})
+		.join(" ");
+
+	const avg = Math.round(history.reduce((a, b) => a + b, 0) / history.length);
+
+	return (
+		<span title={`Avg: ${avg}ms / Min: ${min}ms / Max: ${max}ms`} className="inline-flex items-center">
+			<svg width={width} height={height} className="overflow-visible" role="img" aria-label="Response time sparkline">
+				<polyline points={points} fill="none" stroke="var(--accent)" strokeWidth={1.5} strokeLinejoin="round" strokeLinecap="round" />
+			</svg>
+		</span>
+	);
+}

--- a/web/src/components/RouteCard.tsx
+++ b/web/src/components/RouteCard.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight, Check, Copy, Link, Lock, Star } from "lucide-react";
-import { useState } from "react";
+import React, { useState } from "react";
 import type { Route } from "../types";
 import { HealthDot } from "./HealthDot";
 import { ServiceIcon } from "./ServiceIcon";
@@ -11,10 +11,19 @@ interface RouteCardProps {
 	view: "grid" | "list";
 	isFavorite: boolean;
 	onToggleFavorite: (id: string) => void;
+	onSelect?: (id: string) => void;
+	isFocused?: boolean;
 }
 
-export function RouteCard({ route, index, view, isFavorite, onToggleFavorite }: RouteCardProps) {
+export function RouteCard({ route, index, view, isFavorite, onToggleFavorite, onSelect, isFocused }: RouteCardProps) {
 	const [copied, setCopied] = useState(false);
+	const cardRef = React.useRef<HTMLButtonElement>(null);
+
+	React.useEffect(() => {
+		if (isFocused && cardRef.current) {
+			cardRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
+		}
+	}, [isFocused]);
 
 	const truncatedUrl = route.url ? route.url.replace(/^https?:\/\//, "").replace(/\/$/, "") : "";
 
@@ -33,13 +42,15 @@ export function RouteCard({ route, index, view, isFavorite, onToggleFavorite }: 
 		onToggleFavorite(route.id);
 	};
 
+	const focusRing = isFocused ? "ring-2 ring-accent ring-offset-2 ring-offset-deep" : "";
+
 	if (view === "list") {
 		return (
-			<a
-				href={route.url || "#"}
-				target="_blank"
-				rel="noopener noreferrer"
-				className="animate-card-enter group flex items-center gap-4 px-4 py-3 bg-card border border-line rounded-lg hover:border-line-hover transition-all duration-200 hover:shadow-[var(--shadow-card-hover)]"
+			<button
+				ref={cardRef}
+				type="button"
+				onClick={() => onSelect?.(route.id)}
+				className={`animate-card-enter group flex items-center gap-4 px-4 py-3 bg-card border border-line rounded-lg hover:border-line-hover transition-all duration-200 hover:shadow-[var(--shadow-card-hover)] cursor-pointer text-left w-full ${focusRing}`}
 				style={{ animationDelay: `${index * 30}ms` }}
 			>
 				<button
@@ -61,6 +72,7 @@ export function RouteCard({ route, index, view, isFavorite, onToggleFavorite }: 
 						{route.tls && <Lock className="w-3 h-3 text-success flex-shrink-0" />}
 						<HealthDot health={route.health} checkedAt={route.healthCheckedAt} />
 						{route.healthHistory && <Sparkline history={route.healthHistory} />}
+						<ResponseTimeBadge ms={route.responseTimeMs} />
 					</div>
 					{route.description && <p className="text-xs text-tx3 truncate mt-0.5">{route.description}</p>}
 				</div>
@@ -81,17 +93,28 @@ export function RouteCard({ route, index, view, isFavorite, onToggleFavorite }: 
 					{copied ? <Check className="w-3.5 h-3.5 text-success" /> : <Copy className="w-3.5 h-3.5" />}
 				</button>
 
-				<ArrowUpRight className="w-4 h-4 text-tx3 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
-			</a>
+				{route.url && (
+					<a
+						href={route.url}
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={(e) => e.stopPropagation()}
+						className="flex-shrink-0 p-1 text-tx3 opacity-0 group-hover:opacity-100 hover:text-accent transition-all"
+						title="Open URL"
+					>
+						<ArrowUpRight className="w-4 h-4" />
+					</a>
+				)}
+			</button>
 		);
 	}
 
 	return (
-		<a
-			href={route.url || "#"}
-			target="_blank"
-			rel="noopener noreferrer"
-			className="animate-card-enter group relative flex flex-col bg-card border border-line rounded-xl overflow-hidden transition-all duration-300 hover:border-line-hover hover:shadow-[var(--shadow-card-hover)] hover:-translate-y-1"
+		<button
+			ref={cardRef}
+			type="button"
+			onClick={() => onSelect?.(route.id)}
+			className={`animate-card-enter group relative flex flex-col bg-card border border-line rounded-xl overflow-hidden transition-all duration-300 hover:border-line-hover hover:shadow-[var(--shadow-card-hover)] hover:-translate-y-1 cursor-pointer text-left w-full ${focusRing}`}
 			style={{
 				animationDelay: `${index * 50}ms`,
 				boxShadow: "var(--shadow-card)",
@@ -111,6 +134,7 @@ export function RouteCard({ route, index, view, isFavorite, onToggleFavorite }: 
 							<h3 className="font-display font-semibold text-tx1 truncate text-[15px] leading-tight">{route.title}</h3>
 							{route.tls && <Lock className="w-3.5 h-3.5 text-success flex-shrink-0" />}
 							<HealthDot health={route.health} checkedAt={route.healthCheckedAt} size="md" />
+							<ResponseTimeBadge ms={route.responseTimeMs} />
 						</div>
 						{route.description && <p className="text-xs text-tx2 mt-1 line-clamp-2 leading-relaxed">{route.description}</p>}
 					</div>
@@ -152,11 +176,30 @@ export function RouteCard({ route, index, view, isFavorite, onToggleFavorite }: 
 				>
 					{copied ? <Check className="w-3.5 h-3.5 text-success" /> : <Copy className="w-3.5 h-3.5" />}
 				</button>
-				<div className="p-1.5 rounded-md bg-elevated/80 backdrop-blur-sm border border-line text-tx3">
-					<ArrowUpRight className="w-3.5 h-3.5" />
-				</div>
+				{route.url && (
+					<a
+						href={route.url}
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={(e) => e.stopPropagation()}
+						className="p-1.5 rounded-md bg-elevated/80 backdrop-blur-sm border border-line text-tx3 hover:text-accent hover:border-accent/30 transition-colors"
+						title="Open URL"
+					>
+						<ArrowUpRight className="w-3.5 h-3.5" />
+					</a>
+				)}
 			</div>
-		</a>
+		</button>
+	);
+}
+
+function ResponseTimeBadge({ ms }: { ms?: number }) {
+	if (ms == null || ms <= 0) return null;
+	const color = ms < 200 ? "text-success" : ms < 1000 ? "text-amber-500" : "text-danger";
+	return (
+		<span className={`font-mono text-[10px] ${color} flex-shrink-0`} title={`Response time: ${ms}ms`}>
+			{ms}ms
+		</span>
 	);
 }
 

--- a/web/src/components/RouteDetailPanel.tsx
+++ b/web/src/components/RouteDetailPanel.tsx
@@ -1,0 +1,179 @@
+import { ArrowUpRight, Check, Copy, Star, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { Route } from "../types";
+import { formatDate, timeAgo } from "../utils/time";
+import { HealthDot } from "./HealthDot";
+import { ResponseTimeSparkline } from "./ResponseTimeSparkline";
+import { ServiceIcon } from "./ServiceIcon";
+import { Sparkline } from "./Sparkline";
+
+interface RouteDetailPanelProps {
+	route: Route;
+	isFavorite: boolean;
+	onToggleFavorite: (id: string) => void;
+	onClose: () => void;
+}
+
+export function RouteDetailPanel({ route, isFavorite, onToggleFavorite, onClose }: RouteDetailPanelProps) {
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onClose();
+		};
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [onClose]);
+
+	const handleCopy = () => {
+		navigator.clipboard.writeText(route.url).then(() => {
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
+		});
+	};
+
+	const uptimePercent =
+		route.healthHistory && route.healthHistory.length > 0
+			? Math.round((route.healthHistory.filter((h) => h === "healthy").length / route.healthHistory.length) * 100)
+			: null;
+
+	const rtHistory = route.responseTimeHistory;
+	const rtAvg = rtHistory && rtHistory.length > 0 ? Math.round(rtHistory.reduce((a, b) => a + b, 0) / rtHistory.length) : null;
+	const rtMin = rtHistory && rtHistory.length > 0 ? Math.min(...rtHistory) : null;
+	const rtMax = rtHistory && rtHistory.length > 0 ? Math.max(...rtHistory) : null;
+
+	return (
+		<>
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop overlay dismiss */}
+			<div role="presentation" className="fixed inset-0 z-50 bg-deep/60 backdrop-blur-sm animate-overlay-fade-in" onClick={onClose} />
+
+			{/* Panel */}
+			<div className="fixed inset-y-0 right-0 z-50 w-[480px] max-w-full bg-card border-l border-line overflow-y-auto animate-slide-in-right">
+				{/* Header */}
+				<div className="sticky top-0 bg-card/90 backdrop-blur-sm border-b border-line px-6 py-4 flex items-center gap-3">
+					<div className="w-10 h-10 rounded-lg bg-elevated border border-line flex items-center justify-center text-accent flex-shrink-0">
+						<ServiceIcon serviceName={route.serviceName} resourceName={route.name} size={22} />
+					</div>
+					<div className="flex-1 min-w-0">
+						<h2 className="font-display font-semibold text-tx1 truncate">{route.title}</h2>
+						{route.description && <p className="text-xs text-tx2 truncate">{route.description}</p>}
+					</div>
+					<button type="button" onClick={onClose} className="p-1.5 rounded-lg text-tx3 hover:text-tx1 hover:bg-elevated transition-colors">
+						<X className="w-5 h-5" />
+					</button>
+				</div>
+
+				{/* Actions */}
+				<div className="px-6 py-3 flex items-center gap-2 border-b border-line">
+					{route.url && (
+						<a
+							href={route.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-accent text-deep rounded-lg hover:opacity-90 transition-opacity"
+						>
+							<ArrowUpRight className="w-3.5 h-3.5" />
+							Open
+						</a>
+					)}
+					<button
+						type="button"
+						onClick={handleCopy}
+						className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-elevated border border-line text-tx2 rounded-lg hover:text-tx1 hover:border-line-hover transition-colors"
+					>
+						{copied ? <Check className="w-3.5 h-3.5 text-success" /> : <Copy className="w-3.5 h-3.5" />}
+						{copied ? "Copied" : "Copy URL"}
+					</button>
+					<button
+						type="button"
+						onClick={() => onToggleFavorite(route.id)}
+						className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-elevated border border-line rounded-lg transition-colors ${
+							isFavorite ? "text-amber-400 border-amber-400/30" : "text-tx2 hover:text-amber-400"
+						}`}
+					>
+						<Star className="w-3.5 h-3.5" fill={isFavorite ? "currentColor" : "none"} />
+						{isFavorite ? "Pinned" : "Pin"}
+					</button>
+				</div>
+
+				<div className="px-6 py-5 space-y-6">
+					{/* Metadata grid */}
+					<Section title="Details">
+						<MetaRow label="Namespace" value={route.namespace} />
+						<MetaRow label="Source" value={route.source} />
+						{route.serviceName && <MetaRow label="Service" value={`${route.serviceName}${route.servicePort ? `:${route.servicePort}` : ""}`} />}
+						<MetaRow label="Hosts" value={route.hosts?.join(", ") || "—"} />
+						<MetaRow label="Paths" value={route.paths?.join(", ") || "/"} />
+						<MetaRow label="TLS" value={route.tls ? "Yes" : "No"} />
+						<MetaRow label="Created" value={formatDate(route.createdAt)} />
+						<MetaRow label="Updated" value={formatDate(route.updatedAt)} />
+					</Section>
+
+					{/* Health */}
+					<Section title="Health">
+						<div className="flex items-center gap-3 mb-3">
+							<HealthDot health={route.health} checkedAt={route.healthCheckedAt} size="md" />
+							<span className="text-sm text-tx1 font-medium capitalize">{route.health}</span>
+							{uptimePercent != null && <span className="text-xs font-mono text-tx3">{uptimePercent}% uptime</span>}
+							{route.healthCheckedAt && <span className="text-xs text-tx3 ml-auto">{timeAgo(route.healthCheckedAt)}</span>}
+						</div>
+						{route.healthHistory && route.healthHistory.length > 1 && <Sparkline history={route.healthHistory} width={320} height={16} />}
+					</Section>
+
+					{/* Response time */}
+					{route.responseTimeMs != null && route.responseTimeMs > 0 && (
+						<Section title="Response Time">
+							<div className="flex items-center gap-3 mb-3">
+								<ResponseTimeBadgeLg ms={route.responseTimeMs} />
+								{rtAvg != null && (
+									<div className="flex gap-4 text-xs font-mono text-tx3">
+										<span>avg {rtAvg}ms</span>
+										<span>min {rtMin}ms</span>
+										<span>max {rtMax}ms</span>
+									</div>
+								)}
+							</div>
+							{rtHistory && rtHistory.length > 1 && <ResponseTimeSparkline history={rtHistory} width={320} height={24} />}
+						</Section>
+					)}
+
+					{/* Labels */}
+					{route.labels && Object.keys(route.labels).length > 0 && (
+						<Section title="Labels">
+							<div className="flex flex-wrap gap-1.5">
+								{Object.entries(route.labels).map(([k, v]) => (
+									<span key={k} className="text-[10px] font-mono px-2 py-1 rounded bg-elevated text-tx2 border border-line">
+										{k}={v}
+									</span>
+								))}
+							</div>
+						</Section>
+					)}
+				</div>
+			</div>
+		</>
+	);
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+	return (
+		<div>
+			<h3 className="text-xs font-semibold uppercase tracking-wider text-tx3 mb-3">{title}</h3>
+			{children}
+		</div>
+	);
+}
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="flex items-baseline py-1.5 gap-3">
+			<span className="text-xs text-tx3 w-20 flex-shrink-0">{label}</span>
+			<span className="text-sm text-tx1 font-mono truncate">{value}</span>
+		</div>
+	);
+}
+
+function ResponseTimeBadgeLg({ ms }: { ms: number }) {
+	const color = ms < 200 ? "text-success" : ms < 1000 ? "text-amber-500" : "text-danger";
+	return <span className={`font-mono text-lg font-semibold ${color}`}>{ms}ms</span>;
+}

--- a/web/src/components/RouteGrid.tsx
+++ b/web/src/components/RouteGrid.tsx
@@ -9,9 +9,20 @@ interface RouteGridProps {
 	isFavorite: (id: string) => boolean;
 	onToggleFavorite: (id: string) => void;
 	favorites: Set<string>;
+	onSelectRoute?: (id: string) => void;
+	focusedRouteId?: string | null;
 }
 
-export function RouteGrid({ groupedRoutes, view, allRoutes, isFavorite, onToggleFavorite, favorites }: RouteGridProps) {
+export function RouteGrid({
+	groupedRoutes,
+	view,
+	allRoutes,
+	isFavorite,
+	onToggleFavorite,
+	favorites,
+	onSelectRoute,
+	focusedRouteId,
+}: RouteGridProps) {
 	const groups = Object.entries(groupedRoutes);
 	let globalIndex = 0;
 
@@ -33,7 +44,16 @@ export function RouteGrid({ groupedRoutes, view, allRoutes, isFavorite, onToggle
 						{pinnedRoutes.map((route) => {
 							const idx = globalIndex++;
 							return (
-								<RouteCard key={`pinned-${route.id}`} route={route} index={idx} view={view} isFavorite={true} onToggleFavorite={onToggleFavorite} />
+								<RouteCard
+									key={`pinned-${route.id}`}
+									route={route}
+									index={idx}
+									view={view}
+									isFavorite={true}
+									onToggleFavorite={onToggleFavorite}
+									onSelect={onSelectRoute}
+									isFocused={focusedRouteId === route.id}
+								/>
 							);
 						})}
 					</div>
@@ -60,6 +80,8 @@ export function RouteGrid({ groupedRoutes, view, allRoutes, isFavorite, onToggle
 									view={view}
 									isFavorite={isFavorite(route.id)}
 									onToggleFavorite={onToggleFavorite}
+									onSelect={onSelectRoute}
+									isFocused={focusedRouteId === route.id}
 								/>
 							);
 						})}

--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -1,22 +1,28 @@
 import { Search, X } from "lucide-react";
+import React, { useState } from "react";
 
 interface SearchBarProps {
 	value: string;
 	onChange: (value: string) => void;
 }
 
-export function SearchBar({ value, onChange }: SearchBarProps) {
+export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(({ value, onChange }, ref) => {
+	const [focused, setFocused] = useState(false);
+
 	return (
 		<div className="relative">
 			<Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-tx3" />
 			<input
+				ref={ref}
 				type="text"
 				value={value}
 				onChange={(e) => onChange(e.target.value)}
+				onFocus={() => setFocused(true)}
+				onBlur={() => setFocused(false)}
 				placeholder="Search routes..."
 				className="w-full pl-10 pr-9 py-2 bg-surface border border-line rounded-lg text-sm text-tx1 placeholder-tx3 outline-none transition-colors focus:border-accent focus:ring-1 focus:ring-accent/20 font-body"
 			/>
-			{value && (
+			{value ? (
 				<button
 					type="button"
 					onClick={() => onChange("")}
@@ -24,7 +30,11 @@ export function SearchBar({ value, onChange }: SearchBarProps) {
 				>
 					<X className="w-4 h-4" />
 				</button>
+			) : (
+				!focused && (
+					<span className="absolute right-3 top-1/2 -translate-y-1/2 text-[10px] font-mono text-tx3 border border-line rounded px-1 py-0.5">/</span>
+				)
 			)}
 		</div>
 	);
-}
+});

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -1,28 +1,15 @@
 import { Moon, Sun } from "lucide-react";
-import { useEffect, useState } from "react";
 
-export function ThemeToggle() {
-	const [dark, setDark] = useState(() => {
-		if (typeof window === "undefined") return true;
-		const saved = localStorage.getItem("routeboard-theme");
-		if (saved) return saved === "dark";
-		return true;
-	});
+interface ThemeToggleProps {
+	dark: boolean;
+	onToggle: () => void;
+}
 
-	useEffect(() => {
-		const root = document.documentElement;
-		if (dark) {
-			root.classList.add("dark");
-		} else {
-			root.classList.remove("dark");
-		}
-		localStorage.setItem("routeboard-theme", dark ? "dark" : "light");
-	}, [dark]);
-
+export function ThemeToggle({ dark, onToggle }: ThemeToggleProps) {
 	return (
 		<button
 			type="button"
-			onClick={() => setDark(!dark)}
+			onClick={onToggle}
 			className="p-2 rounded-lg border border-line bg-surface text-tx2 hover:text-tx1 hover:border-line-hover transition-colors"
 			title={dark ? "Switch to light mode" : "Switch to dark mode"}
 		>

--- a/web/src/hooks/useKeyboardNav.ts
+++ b/web/src/hooks/useKeyboardNav.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useState } from "react";
+import type { Route } from "../types";
+
+interface UseKeyboardNavOptions {
+	routes: Route[];
+	disabled: boolean;
+	searchInputRef: React.RefObject<HTMLInputElement | null>;
+	onSelectRoute: (id: string) => void;
+	onToggleFavorite: (id: string) => void;
+}
+
+export function useKeyboardNav({ routes, disabled, searchInputRef, onSelectRoute, onToggleFavorite }: UseKeyboardNavOptions) {
+	const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+
+	// Reset focus when routes change
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset on routes.length change
+	useEffect(() => {
+		setFocusedIndex(-1);
+	}, [routes.length]);
+
+	const focusedRouteId = focusedIndex >= 0 && focusedIndex < routes.length ? routes[focusedIndex].id : null;
+
+	const handleKeyDown = useCallback(
+		(e: KeyboardEvent) => {
+			if (disabled) return;
+
+			// Don't capture when in input/textarea
+			const tag = (e.target as HTMLElement).tagName;
+			if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") {
+				if (e.key === "Escape") {
+					(e.target as HTMLElement).blur();
+					e.preventDefault();
+				}
+				return;
+			}
+
+			switch (e.key) {
+				case "/":
+					e.preventDefault();
+					searchInputRef.current?.focus();
+					break;
+				case "j":
+					e.preventDefault();
+					setFocusedIndex((prev) => Math.min(prev + 1, routes.length - 1));
+					break;
+				case "k":
+					e.preventDefault();
+					setFocusedIndex((prev) => Math.max(prev - 1, 0));
+					break;
+				case "Enter":
+					if (focusedIndex >= 0 && focusedIndex < routes.length) {
+						e.preventDefault();
+						onSelectRoute(routes[focusedIndex].id);
+					}
+					break;
+				case "o":
+					if (focusedIndex >= 0 && focusedIndex < routes.length) {
+						const url = routes[focusedIndex].url;
+						if (url) {
+							e.preventDefault();
+							window.open(url, "_blank", "noopener,noreferrer");
+						}
+					}
+					break;
+				case "f":
+					if (focusedIndex >= 0 && focusedIndex < routes.length) {
+						e.preventDefault();
+						onToggleFavorite(routes[focusedIndex].id);
+					}
+					break;
+				case "Escape":
+					setFocusedIndex(-1);
+					break;
+			}
+		},
+		[disabled, routes, focusedIndex, searchInputRef, onSelectRoute, onToggleFavorite],
+	);
+
+	useEffect(() => {
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [handleKeyDown]);
+
+	return { focusedRouteId };
+}

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+export function useTheme() {
+	const [dark, setDark] = useState(() => {
+		if (typeof window === "undefined") return true;
+		const saved = localStorage.getItem("routeboard-theme");
+		if (saved) return saved === "dark";
+		return true;
+	});
+
+	useEffect(() => {
+		const root = document.documentElement;
+		if (dark) {
+			root.classList.add("dark");
+		} else {
+			root.classList.remove("dark");
+		}
+		localStorage.setItem("routeboard-theme", dark ? "dark" : "light");
+	}, [dark]);
+
+	const toggle = () => setDark((d) => !d);
+
+	return { dark, toggle };
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -147,6 +147,32 @@ body::before {
 	animation: pulse-dot 2s ease-in-out infinite;
 }
 
+@keyframes slide-in-right {
+	from {
+		transform: translateX(100%);
+	}
+	to {
+		transform: translateX(0);
+	}
+}
+
+@keyframes overlay-fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+.animate-slide-in-right {
+	animation: slide-in-right 0.25s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.animate-overlay-fade-in {
+	animation: overlay-fade-in 0.2s ease both;
+}
+
 /* ─── Scrollbar ─── */
 ::-webkit-scrollbar {
 	width: 6px;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -21,6 +21,8 @@ export interface Route {
 	health: "unknown" | "healthy" | "degraded" | "unhealthy";
 	healthCheckedAt?: string;
 	healthHistory?: string[];
+	responseTimeMs?: number;
+	responseTimeHistory?: number[];
 }
 
 export interface ChangeEvent {

--- a/web/src/utils/time.ts
+++ b/web/src/utils/time.ts
@@ -1,0 +1,16 @@
+export function timeAgo(dateStr: string): string {
+	const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+	if (seconds < 10) return "just now";
+	if (seconds < 60) return `${seconds}s ago`;
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	return `${hours}h ago`;
+}
+
+export function formatDate(dateStr: string): string {
+	return new Date(dateStr).toLocaleString(undefined, {
+		dateStyle: "medium",
+		timeStyle: "short",
+	});
+}


### PR DESCRIPTION
Track response times from health checks (model, store, checker) and display color-coded badges on route cards. Add a slide-out detail panel with full route metadata, health history, and response time sparklines. Implement keyboard navigation (j/k/Enter/o/f), search focus (/), and a command palette (Cmd+K) for quick route access, theme toggling, and filtering.