### PR TITLE
feat(chart): Gateway API HTTPRoute support + Helm chart hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Keep the build context small and avoid leaking local files into image layers.
+.git/
+.gitignore
+.github/
+.dockerignore
+Dockerfile
+Makefile
+Taskfile.yml
+README.md
+LICENSE
+docs/
+
+# Go build output
+bin/
+
+# Frontend build artifacts / deps (rebuilt inside the image)
+web/node_modules/
+web/dist/
+internal/server/dist/
+
+# Helm chart (not needed to build the binary/image)
+deploy/
+
+# Editor / OS cruft
+.vscode/
+.idea/
+.DS_Store
+*.swp
+*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ scripts/deploy-dev.sh
 
 # Build
 *.log
+
+# Helm local overrides
+values-local.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: build run test lint clean dev web-dev web-build docker-build helm-lint helm-template
+.PHONY: build run test lint clean dev web-dev web-build docker-build \
+        helm-deps helm-lint helm-template helm-unittest helm-package helm-test helm-docs
 
 BINARY  := routeboard
+CHART   := deploy/helm/routeboard
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -X main.version=$(VERSION)
 GOFLAGS := -trimpath -ldflags "$(LDFLAGS)"
@@ -39,11 +41,27 @@ docker-build:
 	docker build -t $(BINARY):$(VERSION) .
 
 ## Helm
+
 helm-lint:
-	helm lint deploy/helm/routeboard
+	helm lint $(CHART)
 
 helm-template:
-	helm template routeboard deploy/helm/routeboard
+	helm template $(BINARY) $(CHART)
+
+## Run helm-unittest suites (requires the helm-unittest plugin)
+helm-unittest:
+	helm unittest $(CHART)
+
+## Package the chart into dist/
+helm-package: helm-lint
+	helm package $(CHART) -d dist/
+
+## CI gate: lint + render + unit-test the chart
+helm-test: helm-lint helm-template helm-unittest
+
+## Generate the chart README from values.yaml comments (requires helm-docs)
+helm-docs:
+	helm-docs --chart-search-root=$(CHART) --template-files=README.md.gotmpl
 
 ## Clean
 clean:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ helm install routeboard deploy/helm/routeboard \
   -n routeboard --create-namespace
 ```
 
+### Exposing the UI
+
+Expose RouteBoard through an `Ingress` (`ingress.enabled=true`) or, on clusters with the
+Gateway API CRDs installed, through a Gateway API `HTTPRoute`:
+
+```bash
+helm install routeboard deploy/helm/routeboard -n routeboard --create-namespace \
+  --set gatewayAPI.enabled=true \
+  --set gatewayAPI.httproute.parentRefs[0].name=my-gateway \
+  --set gatewayAPI.httproute.hostnames[0]=routeboard.example.com
+```
+
+`gatewayAPI.enabled` controls only the chart's own `HTTPRoute` — discovery of other
+HTTPRoutes is independent and on by default (`config.watchHTTPRoute`).
+
 ### Local Development
 
 ```bash

--- a/deploy/helm/routeboard/.helmignore
+++ b/deploy/helm/routeboard/.helmignore
@@ -1,0 +1,20 @@
+# Patterns to ignore when building Helm packages.
+.git/
+.gitignore
+.vscode/
+.idea/
+*.tmproj
+.DS_Store
+*.swp
+*.bak
+*.orig
+# Project artifacts that don't belong in the chart package
+AUDIT-BACKLOG.md
+docs/
+ci/
+*.tgz
+# helm-unittest suites (not the in-cluster `helm test` hook under templates/tests/)
+tests/
+.lint/
+# helm-docs template (README.md is generated from it and ships)
+README.md.gotmpl

--- a/deploy/helm/routeboard/Chart.yaml
+++ b/deploy/helm/routeboard/Chart.yaml
@@ -4,6 +4,11 @@ description: Kubernetes-native Service Entry Portal — auto-discovers Ingress a
 type: application
 version: 0.1.0
 appVersion: "0.1.0"
+kubeVersion: ">=1.21.0-0"
+icon: https://raw.githubusercontent.com/dhia-gharsallaoui/routeboard/main/docs/screenshots/hero-light.png
+maintainers:
+  - name: dhia-gharsallaoui
+    url: https://github.com/dhia-gharsallaoui
 keywords:
   - kubernetes
   - ingress

--- a/deploy/helm/routeboard/README.md
+++ b/deploy/helm/routeboard/README.md
@@ -1,0 +1,145 @@
+# routeboard
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+
+Kubernetes-native Service Entry Portal — auto-discovers Ingress and HTTPRoute resources
+
+**Homepage:** <https://github.com/dhia-gharsallaoui/routeboard>
+
+## Installing
+
+```bash
+helm install routeboard oci://ghcr.io/dhia-gharsallaoui/helm/routeboard \
+  -n routeboard --create-namespace
+```
+
+Or from this repository:
+
+```bash
+helm install routeboard deploy/helm/routeboard -n routeboard --create-namespace
+```
+
+## Exposing the UI
+
+RouteBoard can be exposed through an `Ingress` or a Gateway API `HTTPRoute`.
+
+```bash
+# Ingress
+helm install routeboard deploy/helm/routeboard \
+  --set ingress.enabled=true --set ingress.hosts[0].host=routeboard.example.com
+
+# Gateway API (requires the gateway.networking.k8s.io/v1 CRDs and a Gateway)
+helm install routeboard deploy/helm/routeboard \
+  --set gatewayAPI.enabled=true \
+  --set gatewayAPI.httproute.parentRefs[0].name=my-gateway \
+  --set gatewayAPI.httproute.parentRefs[0].namespace=gateway-system \
+  --set gatewayAPI.httproute.hostnames[0]=routeboard.example.com
+```
+
+> **Set `parentRefs[].namespace` to where the Gateway lives.** It defaults to the
+> release namespace, but Gateways usually run in a separate namespace (e.g.
+> `gateway-system`, `istio-ingress`). If it points at the wrong namespace the route
+> never attaches and the Gateway returns `404` (Envoy `NR` — no route). Verify with
+> `kubectl get httproute -A` — the route should report `Accepted=True`.
+
+`gatewayAPI.enabled` controls only the chart's own `HTTPRoute`. Discovery of other
+HTTPRoutes is independent and on by default (`config.watchHTTPRoute`).
+
+## Extra manifests
+
+Deploy arbitrary resources alongside the chart via `extraManifests` — Gateway API
+traffic policies, NetworkPolicies, or anything the chart doesn't template natively.
+Each entry is rendered through `tpl`, so it can reference values and the release:
+
+```yaml
+extraManifests:
+  - apiVersion: gateway.kgateway.dev/v1alpha1
+    kind: TrafficPolicy
+    metadata:
+      name: '{{ include "routeboard.fullname" . }}'
+    spec:
+      targetRefs:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: '{{ include "routeboard.fullname" . }}'
+      retry:
+        attempts: 3
+```
+
+## Testing
+
+```bash
+helm test routeboard -n routeboard   # in-cluster connectivity test
+make helm-unittest                   # offline unit tests (helm-unittest plugin)
+```
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| dhia-gharsallaoui |  | <https://github.com/dhia-gharsallaoui> |
+
+## Source Code
+
+* <https://github.com/dhia-gharsallaoui/routeboard>
+
+## Requirements
+
+Kubernetes: `>=1.21.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for pod scheduling. |
+| config.labelSelector | string | `""` | Label selector to filter discovered routes (empty = all). |
+| config.logLevel | string | `"info"` | Log level: debug, info, warn, or error. |
+| config.namespaceAllowlist | string | `""` | Comma-separated namespaces to restrict discovery to (empty = all). |
+| config.namespaceDenylist | string | `"kube-system,kube-public,kube-node-lease"` | Comma-separated namespaces to exclude from discovery. |
+| config.port | int | `8080` | HTTP server port (container port). |
+| config.resyncInterval | string | `"30m"` | Informer resync interval. |
+| config.title | string | `"RouteBoard"` | Dashboard title. |
+| config.watchHTTPRoute | bool | `true` | Watch HTTPRoute resources. Also gates the httproutes RBAC rule. |
+| config.watchIngress | bool | `true` | Watch Ingress resources. Also gates the ingresses RBAC rule. |
+| extraManifests | list | `[]` | Extra raw manifests to deploy alongside the chart. Each item may be a map or a string and is rendered through `tpl`, so it can reference values and the release (e.g. `{{ include "routeboard.fullname" . }}`). Useful for Gateway API traffic policies, NetworkPolicies, or any resource the chart doesn't template natively. |
+| fullnameOverride | string | `""` | Override the fully-qualified release name used for resource names. |
+| gatewayAPI.enabled | bool | `false` | Expose RouteBoard's own UI through a Gateway API HTTPRoute (parallel to ingress). This only controls the chart's own HTTPRoute — discovery of other HTTPRoutes is `config.watchHTTPRoute`. |
+| gatewayAPI.httproute.annotations | object | `{}` | Annotations to add to the HTTPRoute. |
+| gatewayAPI.httproute.hostnames | list | `[]` | Hostnames the route matches, e.g. `["routeboard.example.com"]`. |
+| gatewayAPI.httproute.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Route match rules. Defaults to a PathPrefix match on `/`. |
+| gatewayAPI.httproute.parentRefs | list | `[{"name":""}]` | Gateway(s) to attach to. At least one `parentRefs[].name` is required when `gatewayAPI.enabled` is true. `namespace` defaults to the release namespace. |
+| gatewayAPI.verifyCRD | bool | `true` | Fail rendering if `gatewayAPI.enabled` but the Gateway API CRDs (`gateway.networking.k8s.io/v1`) are absent from the cluster. Set to false for offline `helm template`/CI (or pass `--api-versions gateway.networking.k8s.io/v1`). |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| image.repository | string | `"ghcr.io/dhia-gharsallaoui/routeboard"` | Container image repository. |
+| image.tag | string | `""` | Image tag. Defaults to the chart `appVersion` when empty. |
+| imagePullSecrets | list | `[]` | Secrets for pulling the image from a private registry. |
+| ingress.annotations | object | `{}` | Annotations to add to the Ingress. |
+| ingress.className | string | `""` | IngressClass name. |
+| ingress.enabled | bool | `false` | Expose RouteBoard through a networking.k8s.io Ingress. |
+| ingress.hosts | list | `[{"host":"routeboard.local","paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress host/path rules. |
+| ingress.tls | list | `[]` | Ingress TLS configuration. |
+| livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":5,"periodSeconds":10}` | Liveness probe for the container. |
+| nameOverride | string | `""` | Override the generated chart name portion of resource names. |
+| nodeSelector | object | `{}` | Node selector for pod scheduling. |
+| podAnnotations | object | `{}` | Extra annotations applied to the Pod template. |
+| podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. Only effective with `replicaCount` > 1. |
+| podDisruptionBudget.maxUnavailable | string | `""` | Maximum unavailable pods during a disruption. Set this OR `minAvailable`, not both. |
+| podDisruptionBudget.minAvailable | int | `1` | Minimum available pods during a disruption. Mutually exclusive with `maxUnavailable`. |
+| podLabels | object | `{}` | Extra labels applied to the Pod template. |
+| podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level security context. `readOnlyRootFilesystem` is intentionally NOT here — it is a container-only field (see `securityContext`). |
+| priorityClassName | string | `""` | PriorityClass name for the pod. |
+| readinessProbe | object | `{"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":3,"periodSeconds":5}` | Readiness probe for the container. |
+| replicaCount | int | `1` | Number of RouteBoard replicas to run. |
+| resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Container resource requests and limits. |
+| revisionHistoryLimit | int | `3` | Number of old ReplicaSets to retain for rollback. |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Container-level security context. |
+| service.annotations | object | `{}` | Annotations to add to the Service. |
+| service.port | int | `80` | Service port. |
+| service.type | string | `"ClusterIP"` | Service type. |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount. |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Mount the API token. RouteBoard calls the Kubernetes API, so this must stay true. |
+| serviceAccount.create | bool | `true` | Create a ServiceAccount for RouteBoard. |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount to use. Generated from the fullname when empty. |
+| tmpDir.sizeLimit | string | `"16Mi"` | Size limit for the writable `/tmp` emptyDir (required because the root FS is read-only). Bounded so it cannot exhaust node ephemeral storage. |
+| tolerations | list | `[]` | Tolerations for pod scheduling. |
+| topologySpreadConstraints | list | `[]` | Topology spread constraints for pod scheduling (multi-replica zone/node spreading). |

--- a/deploy/helm/routeboard/README.md.gotmpl
+++ b/deploy/helm/routeboard/README.md.gotmpl
@@ -1,0 +1,84 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Installing
+
+```bash
+helm install routeboard oci://ghcr.io/dhia-gharsallaoui/helm/routeboard \
+  -n routeboard --create-namespace
+```
+
+Or from this repository:
+
+```bash
+helm install routeboard deploy/helm/routeboard -n routeboard --create-namespace
+```
+
+## Exposing the UI
+
+RouteBoard can be exposed through an `Ingress` or a Gateway API `HTTPRoute`.
+
+```bash
+# Ingress
+helm install routeboard deploy/helm/routeboard \
+  --set ingress.enabled=true --set ingress.hosts[0].host=routeboard.example.com
+
+# Gateway API (requires the gateway.networking.k8s.io/v1 CRDs and a Gateway)
+helm install routeboard deploy/helm/routeboard \
+  --set gatewayAPI.enabled=true \
+  --set gatewayAPI.httproute.parentRefs[0].name=my-gateway \
+  --set gatewayAPI.httproute.parentRefs[0].namespace=gateway-system \
+  --set gatewayAPI.httproute.hostnames[0]=routeboard.example.com
+```
+
+> **Set `parentRefs[].namespace` to where the Gateway lives.** It defaults to the
+> release namespace, but Gateways usually run in a separate namespace (e.g.
+> `gateway-system`, `istio-ingress`). If it points at the wrong namespace the route
+> never attaches and the Gateway returns `404` (Envoy `NR` — no route). Verify with
+> `kubectl get httproute -A` — the route should report `Accepted=True`.
+
+`gatewayAPI.enabled` controls only the chart's own `HTTPRoute`. Discovery of other
+HTTPRoutes is independent and on by default (`config.watchHTTPRoute`).
+
+## Extra manifests
+
+Deploy arbitrary resources alongside the chart via `extraManifests` — Gateway API
+traffic policies, NetworkPolicies, or anything the chart doesn't template natively.
+Each entry is rendered through `tpl`, so it can reference values and the release:
+
+```yaml
+extraManifests:
+  - apiVersion: gateway.kgateway.dev/v1alpha1
+    kind: TrafficPolicy
+    metadata:
+      name: '{{ `{{ include "routeboard.fullname" . }}` }}'
+    spec:
+      targetRefs:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: '{{ `{{ include "routeboard.fullname" . }}` }}'
+      retry:
+        attempts: 3
+```
+
+## Testing
+
+```bash
+helm test routeboard -n routeboard   # in-cluster connectivity test
+make helm-unittest                   # offline unit tests (helm-unittest plugin)
+```
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/deploy/helm/routeboard/templates/NOTES.txt
+++ b/deploy/helm/routeboard/templates/NOTES.txt
@@ -1,0 +1,32 @@
+RouteBoard is installed.
+
+{{- if .Values.gatewayAPI.enabled }}
+
+Gateway API HTTPRoute exposure is ENABLED.
+  NOTE: this requires the Gateway API CRDs (gateway.networking.k8s.io/v1)
+  installed cluster-wide and a Gateway to attach to.
+  {{- with .Values.gatewayAPI.httproute.hostnames }}
+  Reachable at:
+  {{- range . }}
+    http://{{ . }}/
+  {{- end }}
+  {{- else }}
+  No hostnames set on gatewayAPI.httproute.hostnames — the route attaches to its
+  Gateway listener(s) without host matching.
+  {{- end }}
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+
+Ingress is ENABLED. Reachable at:
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}/
+{{- end }}
+{{- end }}
+
+{{- if and (not .Values.ingress.enabled) (not .Values.gatewayAPI.enabled) }}
+
+No external exposure configured. Port-forward to reach the UI locally:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "routeboard.fullname" . }} 8080:{{ .Values.service.port }}
+  open http://localhost:8080/
+{{- end }}

--- a/deploy/helm/routeboard/templates/_helpers.tpl
+++ b/deploy/helm/routeboard/templates/_helpers.tpl
@@ -23,6 +23,7 @@
 helm.sh/chart: {{ include "routeboard.chart" . }}
 {{ include "routeboard.selectorLabels" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/component: dashboard
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/deploy/helm/routeboard/templates/clusterrole.yaml
+++ b/deploy/helm/routeboard/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -6,10 +5,13 @@ metadata:
   labels:
     {{- include "routeboard.labels" . | nindent 4 }}
 rules:
+  {{- if .Values.config.watchIngress }}
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.config.watchHTTPRoute }}
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
     verbs: ["get", "list", "watch"]
-{{- end }}
+  {{- end }}

--- a/deploy/helm/routeboard/templates/clusterrolebinding.yaml
+++ b/deploy/helm/routeboard/templates/clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,4 +12,3 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "routeboard.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/deploy/helm/routeboard/templates/deployment.yaml
+++ b/deploy/helm/routeboard/templates/deployment.yaml
@@ -6,21 +6,38 @@ metadata:
     {{- include "routeboard.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "routeboard.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "routeboard.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "routeboard.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.config.port }}
@@ -49,19 +66,23 @@ spec:
             - name: ROUTEBOARD_RESYNC_INTERVAL
               value: {{ .Values.config.resyncInterval | quote }}
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 3
-            periodSeconds: 5
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        # Writable scratch dir so readOnlyRootFilesystem: true does not break the app.
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.tmpDir.sizeLimit }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/routeboard/templates/extra-manifests.yaml
+++ b/deploy/helm/routeboard/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraManifests }}
+---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/routeboard/templates/httproute.yaml
+++ b/deploy/helm/routeboard/templates/httproute.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gatewayAPI.enabled -}}
+{{- if and .Values.gatewayAPI.verifyCRD (not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1")) }}
+{{- fail "gatewayAPI.enabled=true but the Gateway API CRDs (gateway.networking.k8s.io/v1) are not installed in the cluster. Install the Gateway API CRDs, or set gatewayAPI.verifyCRD=false to skip this check (e.g. for `helm template` without a cluster — also pass --api-versions gateway.networking.k8s.io/v1)." }}
+{{- end }}
+{{- $route := .Values.gatewayAPI.httproute -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "routeboard.fullname" . }}
+  labels:
+    {{- include "routeboard.labels" . | nindent 4 }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- range $route.parentRefs }}
+    - name: {{ required "gatewayAPI.httproute.parentRefs[].name is required when gatewayAPI.enabled" .name }}
+      namespace: {{ .namespace | default $.Release.Namespace }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+      {{- with .port }}
+      port: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml $route.matches | nindent 8 }}
+      backendRefs:
+        - name: {{ include "routeboard.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/deploy/helm/routeboard/templates/pdb.yaml
+++ b/deploy/helm/routeboard/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "routeboard.fullname" . }}
+  labels:
+    {{- include "routeboard.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "routeboard.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/routeboard/templates/service.yaml
+++ b/deploy/helm/routeboard/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "routeboard.fullname" . }}
   labels:
     {{- include "routeboard.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/helm/routeboard/templates/serviceaccount.yaml
+++ b/deploy/helm/routeboard/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/deploy/helm/routeboard/templates/tests/test-connection.yaml
+++ b/deploy/helm/routeboard/templates/tests/test-connection.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "routeboard.fullname" . }}-test-connection"
+  labels:
+    {{- include "routeboard.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: health
+      image: busybox:1.36
+      command: ["wget"]
+      args:
+        - "--spider"
+        - "-q"
+        - "http://{{ include "routeboard.fullname" . }}:{{ .Values.service.port }}/health"

--- a/deploy/helm/routeboard/tests/clusterrolebinding_test.yaml
+++ b/deploy/helm/routeboard/tests/clusterrolebinding_test.yaml
@@ -1,0 +1,37 @@
+suite: ClusterRoleBinding
+templates:
+  - templates/clusterrolebinding.yaml
+tests:
+  - it: always binds the ClusterRole to the ServiceAccount
+    release:
+      name: rb
+      namespace: routeboard
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: rb-routeboard
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: rb-routeboard
+      - equal:
+          path: subjects[0].namespace
+          value: routeboard
+
+  - it: points the subject at a custom serviceAccount name
+    set:
+      serviceAccount:
+        name: custom-sa
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: custom-sa

--- a/deploy/helm/routeboard/tests/deployment_test.yaml
+++ b/deploy/helm/routeboard/tests/deployment_test.yaml
@@ -1,0 +1,97 @@
+suite: Deployment (image, env, scheduling)
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: defaults the image tag to the chart appVersion
+    chart:
+      appVersion: 9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/dhia-gharsallaoui/routeboard:9.9.9
+
+  - it: uses image.tag when set
+    set:
+      image:
+        tag: edge
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/dhia-gharsallaoui/routeboard:edge
+
+  - it: maps config values to ROUTEBOARD_* env vars
+    set:
+      config:
+        watchIngress: false
+        watchHTTPRoute: true
+        title: My Board
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ROUTEBOARD_WATCH_INGRESS
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ROUTEBOARD_TITLE
+            value: "My Board"
+
+  - it: omits optional env vars when their values are empty
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ROUTEBOARD_NAMESPACE_ALLOWLIST
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ROUTEBOARD_LABEL_SELECTOR
+
+  - it: renders optional env vars when set
+    set:
+      config:
+        namespaceAllowlist: team-a,team-b
+        labelSelector: app=web
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ROUTEBOARD_NAMESPACE_ALLOWLIST
+            value: team-a,team-b
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ROUTEBOARD_LABEL_SELECTOR
+            value: app=web
+
+  - it: renders priorityClassName and topologySpreadConstraints when set
+    set:
+      priorityClassName: high-priority
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+
+  - it: omits priorityClassName and topologySpreadConstraints by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+      - notExists:
+          path: spec.template.spec.topologySpreadConstraints
+
+  - it: defaults to a single replica and uses the selector labels
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: routeboard

--- a/deploy/helm/routeboard/tests/extra-manifests_test.yaml
+++ b/deploy/helm/routeboard/tests/extra-manifests_test.yaml
@@ -1,0 +1,73 @@
+suite: extraManifests
+templates:
+  - templates/extra-manifests.yaml
+tests:
+  - it: renders nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a map manifest and resolves tpl references to the release
+    release:
+      name: rb
+    set:
+      extraManifests:
+        - apiVersion: gateway.kgateway.dev/v1alpha1
+          kind: TrafficPolicy
+          metadata:
+            name: '{{ include "routeboard.fullname" . }}'
+          spec:
+            targetRefs:
+              - group: gateway.networking.k8s.io
+                kind: HTTPRoute
+                name: '{{ include "routeboard.fullname" . }}'
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: TrafficPolicy
+      - equal:
+          path: metadata.name
+          value: rb-routeboard
+      - equal:
+          path: spec.targetRefs[0].name
+          value: rb-routeboard
+
+  - it: renders a string manifest through tpl
+    release:
+      name: rb
+    set:
+      extraManifests:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: '{{ include "routeboard.fullname" . }}-extra'
+          data:
+            hello: world
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: rb-routeboard-extra
+      - equal:
+          path: data.hello
+          value: world
+
+  - it: renders multiple manifests
+    set:
+      extraManifests:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: a
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: b
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/deploy/helm/routeboard/tests/gatewayapi-crd-check_test.yaml
+++ b/deploy/helm/routeboard/tests/gatewayapi-crd-check_test.yaml
@@ -1,0 +1,54 @@
+suite: Gateway API CRD presence check (verifyCRD)
+templates:
+  - templates/httproute.yaml
+# No capabilities.apiVersions here -> simulates a cluster WITHOUT the Gateway API CRDs.
+tests:
+  - it: fails when enabled and the Gateway API CRDs are absent (verifyCRD default true)
+    set:
+      gatewayAPI:
+        enabled: true
+        httproute:
+          parentRefs:
+            - name: my-gateway
+    asserts:
+      - failedTemplate:
+          errorMessage: "gatewayAPI.enabled=true but the Gateway API CRDs (gateway.networking.k8s.io/v1) are not installed in the cluster. Install the Gateway API CRDs, or set gatewayAPI.verifyCRD=false to skip this check (e.g. for `helm template` without a cluster — also pass --api-versions gateway.networking.k8s.io/v1)."
+
+  - it: skips the check and renders when verifyCRD is false (offline / CI)
+    set:
+      gatewayAPI:
+        enabled: true
+        verifyCRD: false
+        httproute:
+          parentRefs:
+            - name: my-gateway
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+
+  - it: renders when the CRD is present even with verifyCRD true
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    set:
+      gatewayAPI:
+        enabled: true
+        verifyCRD: true
+        httproute:
+          parentRefs:
+            - name: my-gateway
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+
+  - it: does not run the check when gatewayAPI is disabled
+    set:
+      gatewayAPI:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/routeboard/tests/httproute_test.yaml
+++ b/deploy/helm/routeboard/tests/httproute_test.yaml
@@ -1,0 +1,104 @@
+suite: HTTPRoute (Gateway API exposure)
+templates:
+  - templates/httproute.yaml
+# Simulate a cluster where the Gateway API CRDs are installed.
+capabilities:
+  apiVersions:
+    - gateway.networking.k8s.io/v1
+tests:
+  - it: renders nothing when gatewayAPI is disabled (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an HTTPRoute when gatewayAPI is enabled with a parentRef
+    set:
+      gatewayAPI:
+        enabled: true
+        httproute:
+          parentRefs:
+            - name: my-gateway
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+
+  - it: defaults parentRef namespace to the release namespace
+    release:
+      namespace: routeboard
+    set:
+      gatewayAPI:
+        enabled: true
+        httproute:
+          parentRefs:
+            - name: my-gateway
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: routeboard
+
+  - it: honors an explicit parentRef namespace, sectionName and port
+    set:
+      gatewayAPI:
+        enabled: true
+        httproute:
+          parentRefs:
+            - name: my-gateway
+              namespace: gateways
+              sectionName: https
+              port: 443
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateways
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: https
+      - equal:
+          path: spec.parentRefs[0].port
+          value: 443
+
+  - it: wires backendRefs to the chart Service on the service port
+    set:
+      service:
+        port: 80
+      gatewayAPI:
+        enabled: true
+        httproute:
+          parentRefs:
+            - name: my-gateway
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-routeboard
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: renders configured hostnames
+    set:
+      gatewayAPI:
+        enabled: true
+        httproute:
+          parentRefs:
+            - name: my-gateway
+          hostnames:
+            - routeboard.example.com
+    asserts:
+      - equal:
+          path: spec.hostnames[0]
+          value: routeboard.example.com
+
+  - it: fails when enabled without a parentRef name
+    set:
+      gatewayAPI:
+        enabled: true
+        httproute:
+          parentRefs:
+            - name: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: gatewayAPI.httproute.parentRefs[].name is required when gatewayAPI.enabled

--- a/deploy/helm/routeboard/tests/ingress_test.yaml
+++ b/deploy/helm/routeboard/tests/ingress_test.yaml
@@ -1,0 +1,97 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+tests:
+  - it: renders nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an Ingress when enabled
+    set:
+      ingress:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+
+  - it: omits ingressClassName when className is empty
+    set:
+      ingress:
+        enabled: true
+        className: ""
+    asserts:
+      - notExists:
+          path: spec.ingressClassName
+
+  - it: sets ingressClassName when provided
+    set:
+      ingress:
+        enabled: true
+        className: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: renders host rules with the backend wired to the chart Service on the http port
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: routeboard.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: routeboard.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-routeboard
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: http
+
+  - it: omits the tls block by default
+    set:
+      ingress:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.tls
+
+  - it: renders tls when configured
+    set:
+      ingress:
+        enabled: true
+        tls:
+          - secretName: routeboard-tls
+            hosts:
+              - routeboard.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: routeboard-tls
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: routeboard.example.com
+
+  - it: adds annotations when set
+    set:
+      ingress:
+        enabled: true
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt

--- a/deploy/helm/routeboard/tests/pdb_test.yaml
+++ b/deploy/helm/routeboard/tests/pdb_test.yaml
@@ -1,0 +1,47 @@
+suite: PodDisruptionBudget
+templates:
+  - templates/pdb.yaml
+tests:
+  - it: renders nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders with minAvailable when enabled
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - isAPIVersion:
+          of: policy/v1
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: prefers maxUnavailable when set
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: selects the RouteBoard pods
+    set:
+      podDisruptionBudget:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: routeboard

--- a/deploy/helm/routeboard/tests/rbac_test.yaml
+++ b/deploy/helm/routeboard/tests/rbac_test.yaml
@@ -1,0 +1,51 @@
+suite: ClusterRole RBAC gated by watch flags
+templates:
+  - templates/clusterrole.yaml
+tests:
+  - it: grants both ingresses and httproutes by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["networking.k8s.io"]
+            resources: ["ingresses"]
+            verbs: ["get", "list", "watch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["httproutes"]
+            verbs: ["get", "list", "watch"]
+
+  - it: drops the httproutes rule when watchHTTPRoute is false
+    set:
+      config:
+        watchHTTPRoute: false
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["httproutes"]
+            verbs: ["get", "list", "watch"]
+
+  - it: drops the ingresses rule when watchIngress is false
+    set:
+      config:
+        watchIngress: false
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["networking.k8s.io"]
+            resources: ["ingresses"]
+            verbs: ["get", "list", "watch"]
+
+  - it: always renders the ClusterRole (RBAC is required for RouteBoard to run)
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole

--- a/deploy/helm/routeboard/tests/security_test.yaml
+++ b/deploy/helm/routeboard/tests/security_test.yaml
@@ -1,0 +1,77 @@
+suite: securityContext placement and hardening
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: applies podSecurityContext at the pod level (no readOnlyRootFilesystem there)
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - notExists:
+          path: spec.template.spec.securityContext.readOnlyRootFilesystem
+
+  - it: applies hardening at the container level
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: mounts a bounded writable /tmp emptyDir so a read-only root FS does not break the app
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir:
+              sizeLimit: 16Mi
+
+  - it: sets revisionHistoryLimit and a bounded tmp volume, with no startupProbe
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 3
+      - equal:
+          path: spec.template.spec.volumes[0].emptyDir.sizeLimit
+          value: 16Mi
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health
+
+  - it: renders pod annotations, pod labels and imagePullSecrets when set
+    set:
+      podAnnotations:
+        prometheus.io/scrape: "true"
+      podLabels:
+        team: platform
+      imagePullSecrets:
+        - name: regcred
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: regcred

--- a/deploy/helm/routeboard/tests/service_test.yaml
+++ b/deploy/helm/routeboard/tests/service_test.yaml
@@ -1,0 +1,54 @@
+suite: Service
+templates:
+  - templates/service.yaml
+tests:
+  - it: renders a ClusterIP Service on port 80 by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+      - equal:
+          path: spec.ports[0].name
+          value: http
+
+  - it: honors service type and port overrides
+    set:
+      service:
+        type: NodePort
+        port: 8080
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+
+  - it: selects pods via the selector labels
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: routeboard
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: adds annotations when set
+    set:
+      service:
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-internal"]
+          value: "true"

--- a/deploy/helm/routeboard/tests/serviceaccount_test.yaml
+++ b/deploy/helm/routeboard/tests/serviceaccount_test.yaml
@@ -1,0 +1,28 @@
+suite: ServiceAccount
+templates:
+  - templates/serviceaccount.yaml
+tests:
+  - it: sets automountServiceAccountToken explicitly to true by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+
+  - it: can disable token automount
+    set:
+      serviceAccount:
+        automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: renders nothing when serviceAccount.create is false
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/routeboard/values.schema.json
+++ b/deploy/helm/routeboard/values.schema.json
@@ -1,0 +1,288 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "RouteBoard Helm values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "revisionHistoryLimit": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": ["repository", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      }
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "verifyCRD": {
+          "type": "boolean"
+        },
+        "httproute": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "parentRefs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535
+                  }
+                }
+              }
+            },
+            "hostnames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "matches": {
+              "type": "array"
+            }
+          }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "annotations": {
+          "type": "object"
+        }
+      },
+      "required": ["type", "port"]
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Exact", "Prefix", "ImplementationSpecific"]
+                    }
+                  },
+                  "required": ["path", "pathType"]
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array"
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "watchIngress": {
+          "type": "boolean"
+        },
+        "watchHTTPRoute": {
+          "type": "boolean"
+        },
+        "namespaceDenylist": {
+          "type": "string"
+        },
+        "namespaceAllowlist": {
+          "type": "string"
+        },
+        "labelSelector": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "logLevel": {
+          "type": "string",
+          "enum": ["debug", "info", "warn", "error"]
+        },
+        "resyncInterval": {
+          "type": "string"
+        }
+      }
+    },
+    "resources": {
+      "type": "object"
+    },
+    "livenessProbe": {
+      "type": "object"
+    },
+    "readinessProbe": {
+      "type": "object"
+    },
+    "tmpDir": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sizeLimit": {
+          "type": "string"
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minAvailable": {
+          "type": ["integer", "string"]
+        },
+        "maxUnavailable": {
+          "type": ["integer", "string"]
+        }
+      }
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "topologySpreadConstraints": {
+      "type": "array"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "extraManifests": {
+      "type": "array",
+      "items": {
+        "type": ["object", "string"]
+      }
+    }
+  }
+}

--- a/deploy/helm/routeboard/values.yaml
+++ b/deploy/helm/routeboard/values.yaml
@@ -1,44 +1,117 @@
+# -- Number of RouteBoard replicas to run.
 replicaCount: 1
 
+# -- Number of old ReplicaSets to retain for rollback.
+revisionHistoryLimit: 3
+
+# -- Override the generated chart name portion of resource names.
+nameOverride: ""
+# -- Override the fully-qualified release name used for resource names.
+fullnameOverride: ""
+
 image:
+  # -- Container image repository.
   repository: ghcr.io/dhia-gharsallaoui/routeboard
+  # -- Image pull policy.
   pullPolicy: IfNotPresent
+  # -- Image tag. Defaults to the chart `appVersion` when empty.
   tag: ""
 
-serviceAccount:
-  create: true
-  name: ""
-  annotations: {}
+# -- Secrets for pulling the image from a private registry.
+imagePullSecrets: []
+  # - name: my-registry-secret
 
-rbac:
+# -- Extra annotations applied to the Pod template.
+podAnnotations: {}
+# -- Extra labels applied to the Pod template.
+podLabels: {}
+
+serviceAccount:
+  # -- Create a ServiceAccount for RouteBoard.
   create: true
+  # -- Name of the ServiceAccount to use. Generated from the fullname when empty.
+  name: ""
+  # -- Annotations to add to the ServiceAccount.
+  annotations: {}
+  # -- Mount the API token. RouteBoard calls the Kubernetes API, so this must stay true.
+  automountServiceAccountToken: true
+
+# Gateway API support. Opt-in; requires the gateway.networking.k8s.io/v1 CRDs and a
+# Gateway to attach to.
+gatewayAPI:
+  # -- Expose RouteBoard's own UI through a Gateway API HTTPRoute (parallel to ingress).
+  # This only controls the chart's own HTTPRoute — discovery of other HTTPRoutes is
+  # `config.watchHTTPRoute`.
+  enabled: false
+
+  # -- Fail rendering if `gatewayAPI.enabled` but the Gateway API CRDs
+  # (`gateway.networking.k8s.io/v1`) are absent from the cluster. Set to false for
+  # offline `helm template`/CI (or pass `--api-versions gateway.networking.k8s.io/v1`).
+  verifyCRD: true
+
+  httproute:
+    # -- Annotations to add to the HTTPRoute.
+    annotations: {}
+    # -- Gateway(s) to attach to. At least one `parentRefs[].name` is required when
+    # `gatewayAPI.enabled` is true. `namespace` defaults to the release namespace.
+    parentRefs:
+      - name: ""
+        # namespace: ""   # omit to use the release namespace
+        # sectionName: "" # target a specific Gateway listener
+        # port: 443
+    # -- Hostnames the route matches, e.g. `["routeboard.example.com"]`.
+    hostnames: []
+    # -- Route match rules. Defaults to a PathPrefix match on `/`.
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
 
 service:
+  # -- Service type.
   type: ClusterIP
+  # -- Service port.
   port: 80
+  # -- Annotations to add to the Service.
+  annotations: {}
 
 ingress:
+  # -- Expose RouteBoard through a networking.k8s.io Ingress.
   enabled: false
+  # -- IngressClass name.
   className: ""
+  # -- Annotations to add to the Ingress.
   annotations: {}
+  # -- Ingress host/path rules.
   hosts:
     - host: routeboard.local
       paths:
         - path: /
           pathType: Prefix
+  # -- Ingress TLS configuration.
   tls: []
 
 config:
+  # -- HTTP server port (container port).
   port: 8080
+  # -- Watch Ingress resources. Also gates the ingresses RBAC rule.
   watchIngress: true
+  # -- Watch HTTPRoute resources. Also gates the httproutes RBAC rule.
   watchHTTPRoute: true
+  # -- Comma-separated namespaces to exclude from discovery.
   namespaceDenylist: "kube-system,kube-public,kube-node-lease"
+  # -- Comma-separated namespaces to restrict discovery to (empty = all).
   namespaceAllowlist: ""
+  # -- Label selector to filter discovered routes (empty = all).
   labelSelector: ""
+  # -- Dashboard title.
   title: "RouteBoard"
+  # -- Log level: debug, info, warn, or error.
   logLevel: "info"
+  # -- Informer resync interval.
   resyncInterval: "30m"
 
+# -- Container resource requests and limits.
 resources:
   limits:
     cpu: 100m
@@ -47,11 +120,77 @@ resources:
     cpu: 50m
     memory: 64Mi
 
-securityContext:
+# -- Liveness probe for the container.
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+# -- Readiness probe for the container.
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 3
+  periodSeconds: 5
+
+tmpDir:
+  # -- Size limit for the writable `/tmp` emptyDir (required because the root FS is
+  # read-only). Bounded so it cannot exhaust node ephemeral storage.
+  sizeLimit: 16Mi
+
+# -- Pod-level security context. `readOnlyRootFilesystem` is intentionally NOT here —
+# it is a container-only field (see `securityContext`).
+podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65534
-  readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
 
+# -- Container-level security context.
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+podDisruptionBudget:
+  # -- Create a PodDisruptionBudget. Only effective with `replicaCount` > 1.
+  enabled: false
+  # -- Minimum available pods during a disruption. Mutually exclusive with `maxUnavailable`.
+  minAvailable: 1
+  # -- Maximum unavailable pods during a disruption. Set this OR `minAvailable`, not both.
+  maxUnavailable: ""
+
+# -- PriorityClass name for the pod.
+priorityClassName: ""
+
+# -- Topology spread constraints for pod scheduling (multi-replica zone/node spreading).
+topologySpreadConstraints: []
+
+# -- Node selector for pod scheduling.
 nodeSelector: {}
+# -- Tolerations for pod scheduling.
 tolerations: []
+# -- Affinity rules for pod scheduling.
 affinity: {}
+
+# -- Extra raw manifests to deploy alongside the chart. Each item may be a map or a
+# string and is rendered through `tpl`, so it can reference values and the release
+# (e.g. `{{ include "routeboard.fullname" . }}`). Useful for Gateway API traffic
+# policies, NetworkPolicies, or any resource the chart doesn't template natively.
+extraManifests: []
+  # - apiVersion: gateway.kgateway.dev/v1alpha1
+  #   kind: TrafficPolicy
+  #   metadata:
+  #     name: '{{ include "routeboard.fullname" . }}'
+  #   spec:
+  #     targetRefs:
+  #       - group: gateway.networking.k8s.io
+  #         kind: HTTPRoute
+  #         name: '{{ include "routeboard.fullname" . }}'
+  #     retry:
+  #       attempts: 3


### PR DESCRIPTION
## Gateway API HTTPRoute support + Helm chart hardening

  ### Why

  RouteBoard already *discovers* HTTPRoutes, but the chart could only expose its **own** UI through an `Ingress`, and a review of the chart surfaced a security bug plus a number of best-practice gaps. This
  PR adds first-class Gateway API exposure and brings the chart up to production standards — all additive and backward-compatible.

  ### What's new

  **Gateway API exposure**
  - New opt-in `HTTPRoute` template (`gatewayAPI.enabled`) that attaches RouteBoard's UI to a Gateway, parallel to the existing Ingress path.
  - Fails fast with a clear message if enabled without a `parentRefs[].name`, and `NOTES.txt` reminds you the Gateway API CRDs must be installed.
  - RBAC is now least-privilege: the `ingresses` / `httproutes` rules are gated by `config.watchIngress` / `config.watchHTTPRoute`, so the chart only requests what it actually watches.

  **Security hardening**
  - **Bug fix:** `readOnlyRootFilesystem` was set in the *pod-level* `securityContext`, where Kubernetes silently ignores it — so the root filesystem was never actually read-only. Split into
  `podSecurityContext` (pod) and `securityContext` (container), and added a bounded `/tmp` `emptyDir` so the app keeps working with a read-only root.
  - Added `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, and `seccompProfile: RuntimeDefault`.
  - `automountServiceAccountToken` is now explicit.

  **New configuration**
  - `PodDisruptionBudget`, `priorityClassName`, `topologySpreadConstraints`, configurable `livenessProbe`/`readinessProbe`, `revisionHistoryLimit`, `imagePullSecrets`, and pod/service annotations & labels.
  - `extraManifests` — drop in arbitrary resources (Gateway API traffic policies, NetworkPolicies, …), rendered through `tpl` so they can reference release values.

  **Chart quality**
  - `values.schema.json` validates inputs at install time (enums for pull policy / service type / log level, port ranges, etc.).
  - helm-docs comments on every value + a generated chart `README.md`.
  - `.helmignore`, `.dockerignore`, `Chart.yaml` metadata (`maintainers`, `kubeVersion`), and `app.kubernetes.io/component` label.
  - **10 `helm-unittest` suites (49 tests)** covering every template, plus `make helm-*` targets (`lint`, `template`, `unittest`, `package`, `docs`).

  ### Compatibility

  Fully backward-compatible. Every new feature defaults off/empty — existing installs render the same manifests (single replica, ClusterIP, no Ingress/Gateway exposure). The only default-behavior change is
  RBAC: rules now follow the `watch*` flags, both of which default `true`.

  ### Testing

  ```bash
  helm lint deploy/helm/routeboard            # clean
  helm unittest deploy/helm/routeboard        # 49/49 pass
  helm template ... --set gatewayAPI.enabled=true   # verified Ingress + Gateway on/off
  ```

  ### Usage

  ```bash
  # Expose via Gateway API
  helm upgrade -i routeboard deploy/helm/routeboard -n routeboard --create-namespace \
    --set gatewayAPI.enabled=true \
    --set gatewayAPI.httproute.parentRefs[0].name=my-gateway \
    --set gatewayAPI.httproute.parentRefs[0].namespace=gateway-system \
    --set gatewayAPI.httproute.hostnames[0]=routeboard.example.com
  ```