### PR TITLE
feat(logging): add ROUTEBOARD_LOG_FORMAT for JSON log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ All configuration is via environment variables. Everything has sensible defaults
 | `ROUTEBOARD_HEALTH_INTERVAL` | `30s` | Health check interval |
 | `ROUTEBOARD_HEALTH_TIMEOUT` | `5s` | Health check timeout |
 | `ROUTEBOARD_LOG_LEVEL` | `info` | Log level (debug/info/warn/error) |
+| `ROUTEBOARD_LOG_FORMAT` | `text` | Log output format (text/json) |
 
 ## Annotations
 

--- a/cmd/routeboard/main.go
+++ b/cmd/routeboard/main.go
@@ -20,7 +20,7 @@ var version = "dev"
 
 func main() {
 	cfg := config.Load()
-	setupLogging(cfg.LogLevel)
+	setupLogging(cfg.LogLevel, cfg.LogFormat)
 
 	slog.Info("starting routeboard", "version", version)
 
@@ -67,7 +67,7 @@ func main() {
 	slog.Info("routeboard stopped")
 }
 
-func setupLogging(level string) {
+func setupLogging(level, format string) {
 	var logLevel slog.Level
 	switch level {
 	case "debug":
@@ -79,5 +79,13 @@ func setupLogging(level string) {
 	default:
 		logLevel = slog.LevelInfo
 	}
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})))
+	opts := &slog.HandlerOptions{Level: logLevel}
+	var handler slog.Handler
+	switch format {
+	case "json":
+		handler = slog.NewJSONHandler(os.Stderr, opts)
+	default:
+		handler = slog.NewTextHandler(os.Stderr, opts)
+	}
+	slog.SetDefault(slog.New(handler))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,9 @@ type Config struct {
 	WatchIngress   bool
 	WatchHTTPRoute bool
 
-	Title    string
-	LogLevel string
+	Title     string
+	LogLevel  string
+	LogFormat string // text, json
 
 	HealthEnabled  bool
 	HealthInterval time.Duration
@@ -47,6 +48,7 @@ func Load() *Config {
 		WatchHTTPRoute: envBool("ROUTEBOARD_WATCH_HTTPROUTE", true),
 		Title:          envStr("ROUTEBOARD_TITLE", "RouteBoard"),
 		LogLevel:       envStr("ROUTEBOARD_LOG_LEVEL", "info"),
+		LogFormat:      envStr("ROUTEBOARD_LOG_FORMAT", "text"),
 		HealthEnabled:  envBool("ROUTEBOARD_HEALTH_ENABLED", true),
 		HealthInterval: envDuration("ROUTEBOARD_HEALTH_INTERVAL", 30*time.Second),
 		HealthTimeout:  envDuration("ROUTEBOARD_HEALTH_TIMEOUT", 5*time.Second),


### PR DESCRIPTION
Closes #6

## What
Adds a `ROUTEBOARD_LOG_FORMAT` env var (default `text`, accepts `json`). When set to `json`, the slog logger uses `slog.NewJSONHandler` instead of the text handler.

## Why
The logger was hardcoded to the text handler, so logs are logfmt. Setting `json` lets RouteBoard's logs integrate cleanly with JSON log pipelines (Vector, Loki, Elasticsearch, VictoriaLogs) without text parsing.

## Changes
- `internal/config/config.go`: new `LogFormat` field (`ROUTEBOARD_LOG_FORMAT`, default `text`)
- `cmd/routeboard/main.go`: `setupLogging` selects JSON vs text handler
- `README.md`: documented the new variable

Default stays `text` — no behaviour change unless opted in. Verified with `go build ./...` + `go vet` + `gofmt`.