### PR TITLE
feat(annotations): add routeboard.io/health to disable per-route health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ metadata:
     routeboard.io/order: "10"                    # Sort order within group
     routeboard.io/hidden: "true"                 # Hide from dashboard
     routeboard.io/url: "https://custom.url"      # Override computed URL
+    routeboard.io/health: "false"                # Keep listed but skip health checks
 ```
 
 ## Architecture

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -66,10 +66,10 @@ func (c *Checker) Run(ctx context.Context) {
 func (c *Checker) checkAll() {
 	routes := c.store.ListAll()
 
-	// Filter to routes with URLs
+	// Filter to routes with URLs that have monitoring enabled
 	var targets []*model.Route
 	for _, r := range routes {
-		if r.URL != "" {
+		if r.URL != "" && !r.MonitorDisabled {
 			targets = append(targets, r)
 		}
 	}

--- a/internal/model/annotations.go
+++ b/internal/model/annotations.go
@@ -28,4 +28,10 @@ func ApplyAnnotations(r *Route, annotations map[string]string) {
 	if v, ok := annotations[AnnotationPrefix+"url"]; ok {
 		r.URL = v
 	}
+	// routeboard.io/health: "false" keeps the route listed but disables health checks.
+	if v, ok := annotations[AnnotationPrefix+"health"]; ok {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			r.MonitorDisabled = !enabled
+		}
+	}
 }

--- a/internal/model/route.go
+++ b/internal/model/route.go
@@ -31,6 +31,9 @@ type Route struct {
 	CreatedAt   time.Time         `json:"createdAt"`
 	UpdatedAt   time.Time         `json:"updatedAt"`
 
+	// MonitorDisabled keeps the route listed but skips health checks. Set via the
+	// routeboard.io/health: "false" annotation.
+	MonitorDisabled     bool           `json:"monitorDisabled,omitempty"`
 	Health              HealthStatus   `json:"health"`
 	HealthCheckedAt     time.Time      `json:"healthCheckedAt,omitempty"`
 	HealthHistory       []HealthStatus `json:"healthHistory,omitempty"`


### PR DESCRIPTION
Closes #7

## What
Adds a `routeboard.io/health: "false"` annotation that keeps a route listed on the board but excludes it from health probing.

## Why
Health checking is all-or-nothing via the global `ROUTEBOARD_HEALTH_ENABLED`. Routes whose URL doesn't answer `HEAD` (e.g. Swagger UIs) show a permanent false `degraded`. The only existing workarounds remove the route (`hidden`, denylist) or blank its URL (also drops the link).

## Changes
- `internal/model/route.go`: new `MonitorDisabled` field
- `internal/model/annotations.go`: parse `routeboard.io/health` (`false` → MonitorDisabled)
- `internal/health/checker.go`: skip routes with `MonitorDisabled` (alongside the existing URL filter)
- `README.md`: documented the annotation

Default unchanged (monitoring stays on). Verified with `go build ./...` + `go vet` + `gofmt`.