### PR TITLE
Wire health check config into Helm chart

### DIFF
--- a/deploy/helm/routeboard/templates/deployment.yaml
+++ b/deploy/helm/routeboard/templates/deployment.yaml
@@ -48,6 +48,12 @@ spec:
               value: {{ .Values.config.logLevel | quote }}
             - name: ROUTEBOARD_RESYNC_INTERVAL
               value: {{ .Values.config.resyncInterval | quote }}
+            - name: ROUTEBOARD_HEALTH_ENABLED
+              value: {{ .Values.config.healthEnabled | quote }}
+            - name: ROUTEBOARD_HEALTH_INTERVAL
+              value: {{ .Values.config.healthInterval | quote }}
+            - name: ROUTEBOARD_HEALTH_TIMEOUT
+              value: {{ .Values.config.healthTimeout | quote }}
           livenessProbe:
             httpGet:
               path: /health

--- a/deploy/helm/routeboard/values.yaml
+++ b/deploy/helm/routeboard/values.yaml
@@ -38,6 +38,9 @@ config:
   title: "RouteBoard"
   logLevel: "info"
   resyncInterval: "30m"
+  healthEnabled: true
+  healthInterval: "30s"
+  healthTimeout: "5s"
 
 resources:
   limits:


### PR DESCRIPTION
App reads `ROUTEBOARD_HEALTH_ENABLED`/`_INTERVAL`/`_TIMEOUT` but the Helm chart never set them. Added the env vars in the deployment template and defaults in `values.yaml`.
