### PR TITLE
fix(chart): move readOnlyRootFilesystem to container securityContext

### DIFF
--- a/deploy/helm/routeboard/templates/deployment.yaml
+++ b/deploy/helm/routeboard/templates/deployment.yaml
@@ -16,11 +16,13 @@ spec:
     spec:
       serviceAccountName: {{ include "routeboard.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.config.port }}

--- a/deploy/helm/routeboard/values.yaml
+++ b/deploy/helm/routeboard/values.yaml
@@ -50,9 +50,11 @@ resources:
     cpu: 50m
     memory: 64Mi
 
-securityContext:
+podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65534
+
+securityContext:
   readOnlyRootFilesystem: true
 
 nodeSelector: {}


### PR DESCRIPTION
## Problem

`values.yaml` had a single `securityContext` block (`runAsNonRoot`, `runAsUser`, `readOnlyRootFilesystem`) that `templates/deployment.yaml` rendered at the **pod** level (`spec.template.spec.securityContext`). `readOnlyRootFilesystem` is a container-only field, so at pod level it is silently ignored (or rejected by strict validation) — the root filesystem was never actually read-only.

## Solution

Split the values into the standard helm-create shape:

- `podSecurityContext` (`runAsNonRoot`, `runAsUser`) → rendered at pod level
- `securityContext` (`readOnlyRootFilesystem`) → rendered at container level

Exactly the same fields as before, just placed where Kubernetes actually honors them. No new hardening added (the app writes nothing to disk, so no `/tmp` emptyDir is needed).

## Testing

- `helm lint deploy/helm/routeboard` — passes (only the usual icon INFO)
- `helm template routeboard deploy/helm/routeboard` — rendered Deployment now shows:

```yaml
    spec:
      securityContext:
        runAsNonRoot: true
        runAsUser: 65534
      containers:
        - name: routeboard
          securityContext:
            readOnlyRootFilesystem: true
```

Fixes #3

> Note: Overlaps with the securityContext split in #5 — this is the minimal standalone fix so the security bug isn't blocked on the larger chart PR; #5 can rebase on top.