### PR TITLE
feat: support JSON log output via ROUTEBOARD_LOG_FORMAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ All configuration is via environment variables. Everything has sensible defaults
 | `ROUTEBOARD_HEALTH_INTERVAL` | `30s` | Health check interval |
 | `ROUTEBOARD_HEALTH_TIMEOUT` | `5s` | Health check timeout |
 | `ROUTEBOARD_LOG_LEVEL` | `info` | Log level (debug/info/warn/error) |
+| `ROUTEBOARD_LOG_FORMAT` | `text` | Log format (text/json) |
 
 ## Annotations
 

--- a/cmd/routeboard/main.go
+++ b/cmd/routeboard/main.go
@@ -20,7 +20,7 @@ var version = "dev"
 
 func main() {
 	cfg := config.Load()
-	setupLogging(cfg.LogLevel)
+	setupLogging(cfg.LogLevel, cfg.LogFormat)
 
 	slog.Info("starting routeboard", "version", version)
 
@@ -67,7 +67,7 @@ func main() {
 	slog.Info("routeboard stopped")
 }
 
-func setupLogging(level string) {
+func setupLogging(level, format string) {
 	var logLevel slog.Level
 	switch level {
 	case "debug":
@@ -79,5 +79,13 @@ func setupLogging(level string) {
 	default:
 		logLevel = slog.LevelInfo
 	}
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})))
+	opts := &slog.HandlerOptions{Level: logLevel}
+	var handler slog.Handler
+	switch format {
+	case "json":
+		handler = slog.NewJSONHandler(os.Stderr, opts)
+	default:
+		handler = slog.NewTextHandler(os.Stderr, opts)
+	}
+	slog.SetDefault(slog.New(handler))
 }

--- a/deploy/helm/routeboard/templates/deployment.yaml
+++ b/deploy/helm/routeboard/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: {{ .Values.config.title | quote }}
             - name: ROUTEBOARD_LOG_LEVEL
               value: {{ .Values.config.logLevel | quote }}
+            - name: ROUTEBOARD_LOG_FORMAT
+              value: {{ .Values.config.logFormat | quote }}
             - name: ROUTEBOARD_RESYNC_INTERVAL
               value: {{ .Values.config.resyncInterval | quote }}
             - name: ROUTEBOARD_HEALTH_ENABLED

--- a/deploy/helm/routeboard/values.yaml
+++ b/deploy/helm/routeboard/values.yaml
@@ -37,6 +37,7 @@ config:
   labelSelector: ""
   title: "RouteBoard"
   logLevel: "info"
+  logFormat: "text"
   resyncInterval: "30m"
   healthEnabled: true
   healthInterval: "30s"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,9 @@ type Config struct {
 	WatchIngress   bool
 	WatchHTTPRoute bool
 
-	Title    string
-	LogLevel string
+	Title     string
+	LogLevel  string
+	LogFormat string // text, json
 
 	HealthEnabled  bool
 	HealthInterval time.Duration
@@ -47,6 +48,7 @@ func Load() *Config {
 		WatchHTTPRoute: envBool("ROUTEBOARD_WATCH_HTTPROUTE", true),
 		Title:          envStr("ROUTEBOARD_TITLE", "RouteBoard"),
 		LogLevel:       envStr("ROUTEBOARD_LOG_LEVEL", "info"),
+		LogFormat:      envStr("ROUTEBOARD_LOG_FORMAT", "text"),
 		HealthEnabled:  envBool("ROUTEBOARD_HEALTH_ENABLED", true),
 		HealthInterval: envDuration("ROUTEBOARD_HEALTH_INTERVAL", 30*time.Second),
 		HealthTimeout:  envDuration("ROUTEBOARD_HEALTH_TIMEOUT", 5*time.Second),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,28 @@
+package config
+
+import "testing"
+
+func TestLoadLogFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"default is text", "", "text"},
+		{"json accepted", "json", "json"},
+		{"text accepted", "text", "text"},
+		{"invalid value passed through for fallback at setup", "yaml", "yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env != "" {
+				t.Setenv("ROUTEBOARD_LOG_FORMAT", tt.env)
+			}
+			cfg := Load()
+			if cfg.LogFormat != tt.want {
+				t.Errorf("LogFormat = %q; want %q", cfg.LogFormat, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The logger is hardcoded to slog's text handler in `cmd/routeboard/main.go`, so all logs come out as logfmt. JSON log pipelines (Vector → Loki/Elasticsearch) need structured output.

## Solution

- Add a `LogFormat` field to the config, populated from `ROUTEBOARD_LOG_FORMAT` (default `text`), following the same `envStr` pattern as `ROUTEBOARD_LOG_LEVEL`.
- `setupLogging` now selects `slog.NewJSONHandler` when the format is `json`; any other value falls back to the text handler, mirroring how invalid log levels fall back to `info`. Default behavior is unchanged.
- Documented the new variable in the README env table.
- Wired `config.logFormat` (default `text`) through the Helm chart, following the existing `logLevel` pattern.

## Testing

- New table-driven test `TestLoadLogFormat` in `internal/config/config_test.go` covering the default, `json`, `text`, and pass-through of unknown values (written first, verified failing before implementation).
- `go build ./...`, `go vet ./...`, `go test ./...` — all pass (36 tests across 8 packages).
- `helm lint deploy/helm/routeboard` — 0 failures.

Fixes #6