### PR TITLE
feat: allow disabling health checks per-route via routeboard.io/health annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ metadata:
     routeboard.io/order: "10"                    # Sort order within group
     routeboard.io/hidden: "true"                 # Hide from dashboard
     routeboard.io/url: "https://custom.url"      # Override computed URL
+    routeboard.io/health: "false"                # Exclude from health checks (route stays listed)
 ```
 
 ## Architecture

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -66,10 +66,10 @@ func (c *Checker) Run(ctx context.Context) {
 func (c *Checker) checkAll() {
 	routes := c.store.ListAll()
 
-	// Filter to routes with URLs
+	// Filter to routes with URLs and health checks enabled
 	var targets []*model.Route
 	for _, r := range routes {
-		if r.URL != "" {
+		if r.URL != "" && !r.HealthDisabled {
 			targets = append(targets, r)
 		}
 	}

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -143,6 +143,29 @@ func TestCheckAllUpdatesStore(t *testing.T) {
 	}
 }
 
+func TestCheckAllSkipsHealthDisabled(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := store.New(nil)
+	s.Set(&model.Route{ID: "disabled", URL: srv.URL, Title: "Disabled", HealthDisabled: true})
+
+	checker := NewChecker(testConfig(), s)
+	checker.checkAll()
+
+	if requests != 0 {
+		t.Errorf("expected 0 requests to health-disabled route, got %d", requests)
+	}
+	route, _ := s.Get("disabled")
+	if route.Health != "" {
+		t.Errorf("route health = %q, want empty (unchanged)", route.Health)
+	}
+}
+
 func TestCheckAllSkipsNoURL(t *testing.T) {
 	s := store.New(nil)
 	s.Set(&model.Route{ID: "no-url", URL: "", Title: "No URL"})

--- a/internal/model/annotations.go
+++ b/internal/model/annotations.go
@@ -28,4 +28,7 @@ func ApplyAnnotations(r *Route, annotations map[string]string) {
 	if v, ok := annotations[AnnotationPrefix+"url"]; ok {
 		r.URL = v
 	}
+	if v, ok := annotations[AnnotationPrefix+"health"]; ok {
+		r.HealthDisabled = v == "false"
+	}
 }

--- a/internal/model/annotations_test.go
+++ b/internal/model/annotations_test.go
@@ -16,6 +16,7 @@ func TestApplyAnnotations(t *testing.T) {
 		"routeboard.io/order":       "5",
 		"routeboard.io/hidden":      "true",
 		"routeboard.io/url":         "https://custom.example.com",
+		"routeboard.io/health":      "false",
 		"unrelated/annotation":      "ignored",
 	}
 
@@ -41,6 +42,21 @@ func TestApplyAnnotations(t *testing.T) {
 	}
 	if r.URL != "https://custom.example.com" {
 		t.Errorf("URL = %q, want %q", r.URL, "https://custom.example.com")
+	}
+	if !r.HealthDisabled {
+		t.Error("HealthDisabled = false, want true")
+	}
+}
+
+func TestApplyAnnotationsHealthNotFalse(t *testing.T) {
+	for _, v := range []string{"true", "", "yes", "0"} {
+		r := &Route{}
+		ApplyAnnotations(r, map[string]string{
+			"routeboard.io/health": v,
+		})
+		if r.HealthDisabled {
+			t.Errorf("HealthDisabled = true for health=%q, want false", v)
+		}
 	}
 }
 

--- a/internal/model/route.go
+++ b/internal/model/route.go
@@ -31,6 +31,7 @@ type Route struct {
 	CreatedAt   time.Time         `json:"createdAt"`
 	UpdatedAt   time.Time         `json:"updatedAt"`
 
+	HealthDisabled      bool           `json:"healthDisabled,omitempty"`
 	Health              HealthStatus   `json:"health"`
 	HealthCheckedAt     time.Time      `json:"healthCheckedAt,omitempty"`
 	HealthHistory       []HealthStatus `json:"healthHistory,omitempty"`


### PR DESCRIPTION
## Problem

Health checking is all-or-nothing via the global `ROUTEBOARD_HEALTH_ENABLED` flag. Routes whose URL doesn't respond to `HEAD` requests (Swagger UIs, some APIs) show a permanent false "degraded"/"unhealthy" status, and the only workaround is disabling health checks for every route.

## Solution

Add a `routeboard.io/health: "false"` annotation that keeps the route listed on the dashboard but excludes it from health probing:

- `internal/model/route.go`: new `Route.HealthDisabled` field (serialized as `healthDisabled`, omitted when false)
- `internal/model/annotations.go`: parse `routeboard.io/health` — only the exact value `"false"` disables, matching the strict boolean parsing of `routeboard.io/hidden`
- `internal/health/checker.go`: `checkAll` now skips routes with `HealthDisabled`, alongside the existing empty-URL filter
- `README.md`: documented the new annotation in the annotations block

## Testing

- Extended `TestApplyAnnotations` to cover `routeboard.io/health: "false"` → `HealthDisabled = true`
- Added `TestApplyAnnotationsHealthNotFalse`: `"true"`, `""`, `"yes"`, `"0"` do not disable
- Added `TestCheckAllSkipsHealthDisabled`: a health-disabled route with a live URL receives zero probe requests and its health status stays unset
- `go build ./...`, `go vet ./...`, `go test -race ./...` — 33 tests pass across 8 packages

Fixes #7