### PR TITLE
fix: resolve HTTPRoute URL scheme from parent Gateway listeners

### DIFF
--- a/deploy/helm/routeboard/templates/clusterrole.yaml
+++ b/deploy/helm/routeboard/templates/clusterrole.yaml
@@ -10,6 +10,6 @@ rules:
     resources: ["ingresses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["httproutes"]
+    resources: ["httproutes", "gateways"]
     verbs: ["get", "list", "watch"]
 {{- end }}

--- a/internal/k8s/httproute.go
+++ b/internal/k8s/httproute.go
@@ -28,11 +28,8 @@ func extractHTTPRouteRoute(hr *gwv1.HTTPRoute) *model.Route {
 	}
 
 	for _, parent := range hr.Spec.ParentRefs {
-		if parent.SectionName != nil {
-			sn := strings.ToLower(string(*parent.SectionName))
-			if strings.Contains(sn, "https") || strings.Contains(sn, "tls") {
-				r.TLS = true
-			}
+		if isTLSParentRef(parent) {
+			r.TLS = true
 		}
 	}
 
@@ -58,4 +55,22 @@ func extractHTTPRouteRoute(hr *gwv1.HTTPRoute) *model.Route {
 	model.ApplyAnnotations(r, hr.Annotations)
 
 	return r
+}
+
+// isTLSParentRef infers whether a parentRef points at a TLS-terminating
+// Gateway listener. HTTPRoutes carry no TLS config themselves and the parent
+// Gateway is not watched, so this relies on the listener port and common
+// listener naming conventions (e.g. "https", "tls", Traefik's "websecure").
+func isTLSParentRef(parent gwv1.ParentReference) bool {
+	if parent.Port != nil && *parent.Port == 443 {
+		return true
+	}
+	if parent.SectionName == nil {
+		return false
+	}
+	sn := strings.ToLower(string(*parent.SectionName))
+	if strings.Contains(sn, "https") || strings.Contains(sn, "tls") {
+		return true
+	}
+	return strings.Contains(sn, "secure") && !strings.Contains(sn, "insecure")
 }

--- a/internal/k8s/httproute.go
+++ b/internal/k8s/httproute.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -10,7 +11,12 @@ import (
 	"github.com/dhia/routeboard/internal/model"
 )
 
-func extractHTTPRouteRoute(hr *gwv1.HTTPRoute) *model.Route {
+// gatewayLookupFunc resolves a Gateway by namespace/name, typically backed by
+// the watcher's Gateway informer cache. It returns nil when the Gateway is
+// not available (not cached yet, missing RBAC, or not watched at all).
+type gatewayLookupFunc func(namespace, name string) *gwv1.Gateway
+
+func extractHTTPRouteRoute(hr *gwv1.HTTPRoute, lookupGateway gatewayLookupFunc) *model.Route {
 	r := &model.Route{
 		ID:          fmt.Sprintf("HTTPRoute:%s/%s", hr.Namespace, hr.Name),
 		Name:        hr.Name,
@@ -28,7 +34,7 @@ func extractHTTPRouteRoute(hr *gwv1.HTTPRoute) *model.Route {
 	}
 
 	for _, parent := range hr.Spec.ParentRefs {
-		if isTLSParentRef(parent) {
+		if parentRefTLS(hr, parent, lookupGateway) {
 			r.TLS = true
 		}
 	}
@@ -57,10 +63,94 @@ func extractHTTPRouteRoute(hr *gwv1.HTTPRoute) *model.Route {
 	return r
 }
 
-// isTLSParentRef infers whether a parentRef points at a TLS-terminating
-// Gateway listener. HTTPRoutes carry no TLS config themselves and the parent
-// Gateway is not watched, so this relies on the listener port and common
-// listener naming conventions (e.g. "https", "tls", Traefik's "websecure").
+// parentRefTLS reports whether a parentRef implies the route is served over
+// TLS. It resolves the referenced Gateway's listeners when available and
+// falls back to the parentRef heuristic otherwise.
+func parentRefTLS(hr *gwv1.HTTPRoute, parent gwv1.ParentReference, lookupGateway gatewayLookupFunc) bool {
+	if !refersToGateway(parent) {
+		return false
+	}
+
+	if lookupGateway != nil {
+		ns := hr.Namespace
+		if parent.Namespace != nil && *parent.Namespace != "" {
+			ns = string(*parent.Namespace)
+		}
+		if gw := lookupGateway(ns, string(parent.Name)); gw != nil {
+			return gatewayListenerTLS(gw, parent, hr.Spec.Hostnames)
+		}
+		slog.Debug("gateway not found in cache, falling back to parentRef heuristic",
+			"gateway", ns+"/"+string(parent.Name),
+			"httproute", hr.Namespace+"/"+hr.Name)
+	}
+
+	return isTLSParentRef(parent)
+}
+
+// refersToGateway reports whether a parentRef targets a Gateway API Gateway.
+// Empty group/kind default to Gateway per the Gateway API spec.
+func refersToGateway(parent gwv1.ParentReference) bool {
+	if parent.Group != nil && *parent.Group != "" && string(*parent.Group) != gwv1.GroupName {
+		return false
+	}
+	if parent.Kind != nil && *parent.Kind != "" && *parent.Kind != "Gateway" {
+		return false
+	}
+	return true
+}
+
+// gatewayListenerTLS reports whether the parentRef selects at least one
+// TLS-terminating listener on the Gateway. Listeners are selected by
+// sectionName when set, otherwise by port when set, otherwise all listeners
+// are considered (preferring HTTPS when listeners are mixed).
+func gatewayListenerTLS(gw *gwv1.Gateway, parent gwv1.ParentReference, routeHostnames []gwv1.Hostname) bool {
+	for _, l := range gw.Spec.Listeners {
+		if parent.SectionName != nil && l.Name != *parent.SectionName {
+			continue
+		}
+		if parent.SectionName == nil && parent.Port != nil && l.Port != *parent.Port {
+			continue
+		}
+		if l.Protocol != gwv1.HTTPSProtocolType && l.Protocol != gwv1.TLSProtocolType {
+			continue
+		}
+		if !listenerHostnameCompatible(l.Hostname, routeHostnames) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// listenerHostnameCompatible reports whether a listener hostname can serve
+// any of the route's hostnames. A nil/empty listener hostname or a route
+// without hostnames matches everything. Wildcards match a leading label
+// suffix (e.g. "*.example.com" serves "app.example.com").
+func listenerHostnameCompatible(listenerHostname *gwv1.Hostname, routeHostnames []gwv1.Hostname) bool {
+	if listenerHostname == nil || *listenerHostname == "" || len(routeHostnames) == 0 {
+		return true
+	}
+	lh := string(*listenerHostname)
+	for _, rh := range routeHostnames {
+		h := string(rh)
+		if h == lh {
+			return true
+		}
+		if strings.HasPrefix(lh, "*.") && strings.HasSuffix(h, lh[1:]) {
+			return true
+		}
+		if strings.HasPrefix(h, "*.") && strings.HasSuffix(lh, h[1:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// isTLSParentRef is the fallback heuristic used when the parent Gateway is
+// not available in the cache (not synced yet, missing RBAC on existing
+// installs): HTTPRoutes carry no TLS config themselves, so this relies on the
+// listener port and common listener naming conventions (e.g. "https", "tls",
+// Traefik's "websecure").
 func isTLSParentRef(parent gwv1.ParentReference) bool {
 	if parent.Port != nil && *parent.Port == 443 {
 		return true

--- a/internal/k8s/httproute_test.go
+++ b/internal/k8s/httproute_test.go
@@ -17,21 +17,175 @@ func portNumber(p int32) *gwv1.PortNumber {
 	return &pn
 }
 
-func TestExtractHTTPRouteRouteScheme(t *testing.T) {
+func hostname(h string) *gwv1.Hostname {
+	hn := gwv1.Hostname(h)
+	return &hn
+}
+
+func namespaceRef(ns string) *gwv1.Namespace {
+	n := gwv1.Namespace(ns)
+	return &n
+}
+
+func gateway(namespace, name string, listeners ...gwv1.Listener) *gwv1.Gateway {
+	return &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       gwv1.GatewaySpec{Listeners: listeners},
+	}
+}
+
+// lookupFrom returns a gatewayLookupFunc backed by a fixed set of Gateways,
+// mirroring how the watcher resolves Gateways from its informer cache.
+func lookupFrom(gateways ...*gwv1.Gateway) gatewayLookupFunc {
+	return func(namespace, name string) *gwv1.Gateway {
+		for _, gw := range gateways {
+			if gw.Namespace == namespace && gw.Name == name {
+				return gw
+			}
+		}
+		return nil
+	}
+}
+
+func newHTTPRoute(parentRefs []gwv1.ParentReference) *gwv1.HTTPRoute {
+	return &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+		Spec: gwv1.HTTPRouteSpec{
+			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: parentRefs},
+			Hostnames:       []gwv1.Hostname{"app.example.com"},
+		},
+	}
+}
+
+func TestExtractHTTPRouteRouteGatewayListenerTLS(t *testing.T) {
+	httpListener := gwv1.Listener{Name: "web", Port: 80, Protocol: gwv1.HTTPProtocolType}
+	httpsListener := gwv1.Listener{Name: "websecure", Port: 443, Protocol: gwv1.HTTPSProtocolType}
+	tlsListener := gwv1.Listener{Name: "passthrough", Port: 8443, Protocol: gwv1.TLSProtocolType}
+
 	tests := []struct {
 		name       string
 		parentRefs []gwv1.ParentReference
+		gateways   []*gwv1.Gateway
 		wantTLS    bool
 		wantURL    string
 	}{
 		{
-			name:       "no parentRef signal defaults to http",
+			name: "sectionName matching HTTPS listener",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gw", SectionName: sectionName("websecure")},
+			},
+			gateways: []*gwv1.Gateway{gateway("default", "gw", httpListener, httpsListener)},
+			wantTLS:  true,
+			wantURL:  "https://app.example.com",
+		},
+		{
+			name: "sectionName matching HTTP listener stays http even if name sounds secure",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gw", SectionName: sectionName("websecure")},
+			},
+			gateways: []*gwv1.Gateway{gateway("default", "gw",
+				gwv1.Listener{Name: "websecure", Port: 80, Protocol: gwv1.HTTPProtocolType})},
+			wantTLS: false,
+			wantURL: "http://app.example.com",
+		},
+		{
+			name: "port matching HTTPS listener",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gw", Port: portNumber(443)},
+			},
+			gateways: []*gwv1.Gateway{gateway("default", "gw", httpListener, httpsListener)},
+			wantTLS:  true,
+			wantURL:  "https://app.example.com",
+		},
+		{
+			name: "port matching HTTP listener stays http",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gw", Port: portNumber(80)},
+			},
+			gateways: []*gwv1.Gateway{gateway("default", "gw", httpListener, httpsListener)},
+			wantTLS:  false,
+			wantURL:  "http://app.example.com",
+		},
+		{
+			name:       "no sectionName or port with mixed listeners prefers https",
+			parentRefs: []gwv1.ParentReference{{Name: "gw"}},
+			gateways:   []*gwv1.Gateway{gateway("default", "gw", httpListener, httpsListener)},
+			wantTLS:    true,
+			wantURL:    "https://app.example.com",
+		},
+		{
+			name:       "no sectionName or port with only HTTP listener stays http",
+			parentRefs: []gwv1.ParentReference{{Name: "gw"}},
+			gateways:   []*gwv1.Gateway{gateway("default", "gw", httpListener)},
+			wantTLS:    false,
+			wantURL:    "http://app.example.com",
+		},
+		{
+			name:       "TLS protocol listener counts as tls",
+			parentRefs: []gwv1.ParentReference{{Name: "gw"}},
+			gateways:   []*gwv1.Gateway{gateway("default", "gw", tlsListener)},
+			wantTLS:    true,
+			wantURL:    "https://app.example.com",
+		},
+		{
+			name: "cross-namespace parentRef resolves gateway in that namespace",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gw", Namespace: namespaceRef("infra")},
+			},
+			gateways: []*gwv1.Gateway{gateway("infra", "gw", httpsListener)},
+			wantTLS:  true,
+			wantURL:  "https://app.example.com",
+		},
+		{
+			name:       "HTTPS listener with matching wildcard hostname",
+			parentRefs: []gwv1.ParentReference{{Name: "gw"}},
+			gateways: []*gwv1.Gateway{gateway("default", "gw",
+				gwv1.Listener{Name: "https", Port: 443, Protocol: gwv1.HTTPSProtocolType, Hostname: hostname("*.example.com")})},
+			wantTLS: true,
+			wantURL: "https://app.example.com",
+		},
+		{
+			name:       "HTTPS listener with incompatible hostname stays http",
+			parentRefs: []gwv1.ParentReference{{Name: "gw"}},
+			gateways: []*gwv1.Gateway{gateway("default", "gw",
+				gwv1.Listener{Name: "https", Port: 443, Protocol: gwv1.HTTPSProtocolType, Hostname: hostname("*.other.com")})},
+			wantTLS: false,
+			wantURL: "http://app.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hr := newHTTPRoute(tt.parentRefs)
+
+			r := extractHTTPRouteRoute(hr, lookupFrom(tt.gateways...))
+
+			if r.TLS != tt.wantTLS {
+				t.Errorf("TLS = %v, want %v", r.TLS, tt.wantTLS)
+			}
+			if r.URL != tt.wantURL {
+				t.Errorf("URL = %q, want %q", r.URL, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestExtractHTTPRouteRouteFallbackHeuristic(t *testing.T) {
+	tests := []struct {
+		name       string
+		parentRefs []gwv1.ParentReference
+		lookup     gatewayLookupFunc
+		wantTLS    bool
+		wantURL    string
+	}{
+		{
+			name:       "nil lookup, no parentRef signal defaults to http",
 			parentRefs: []gwv1.ParentReference{{Name: "gateway"}},
 			wantTLS:    false,
 			wantURL:    "http://app.example.com",
 		},
 		{
-			name: "sectionName https",
+			name: "nil lookup, sectionName https",
 			parentRefs: []gwv1.ParentReference{
 				{Name: "gateway", SectionName: sectionName("https")},
 			},
@@ -39,7 +193,7 @@ func TestExtractHTTPRouteRouteScheme(t *testing.T) {
 			wantURL: "https://app.example.com",
 		},
 		{
-			name: "sectionName tls",
+			name: "nil lookup, sectionName tls",
 			parentRefs: []gwv1.ParentReference{
 				{Name: "gateway", SectionName: sectionName("tls-listener")},
 			},
@@ -47,42 +201,47 @@ func TestExtractHTTPRouteRouteScheme(t *testing.T) {
 			wantURL: "https://app.example.com",
 		},
 		{
-			name: "sectionName websecure (traefik convention)",
+			name: "gateway missing from cache, sectionName websecure (traefik convention)",
 			parentRefs: []gwv1.ParentReference{
 				{Name: "gateway", SectionName: sectionName("websecure")},
 			},
+			lookup:  lookupFrom(), // never finds anything
 			wantTLS: true,
 			wantURL: "https://app.example.com",
 		},
 		{
-			name: "sectionName insecure stays http",
+			name: "gateway missing from cache, sectionName insecure stays http",
 			parentRefs: []gwv1.ParentReference{
 				{Name: "gateway", SectionName: sectionName("web-insecure")},
 			},
+			lookup:  lookupFrom(),
 			wantTLS: false,
 			wantURL: "http://app.example.com",
 		},
 		{
-			name: "sectionName web stays http",
+			name: "gateway missing from cache, sectionName web stays http",
 			parentRefs: []gwv1.ParentReference{
 				{Name: "gateway", SectionName: sectionName("web")},
 			},
+			lookup:  lookupFrom(),
 			wantTLS: false,
 			wantURL: "http://app.example.com",
 		},
 		{
-			name: "port 443 without sectionName",
+			name: "gateway missing from cache, port 443 without sectionName",
 			parentRefs: []gwv1.ParentReference{
 				{Name: "gateway", Port: portNumber(443)},
 			},
+			lookup:  lookupFrom(),
 			wantTLS: true,
 			wantURL: "https://app.example.com",
 		},
 		{
-			name: "port 80 stays http",
+			name: "gateway missing from cache, port 80 stays http",
 			parentRefs: []gwv1.ParentReference{
 				{Name: "gateway", Port: portNumber(80)},
 			},
+			lookup:  lookupFrom(),
 			wantTLS: false,
 			wantURL: "http://app.example.com",
 		},
@@ -99,15 +258,9 @@ func TestExtractHTTPRouteRouteScheme(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hr := &gwv1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
-				Spec: gwv1.HTTPRouteSpec{
-					CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: tt.parentRefs},
-					Hostnames:       []gwv1.Hostname{"app.example.com"},
-				},
-			}
+			hr := newHTTPRoute(tt.parentRefs)
 
-			r := extractHTTPRouteRoute(hr)
+			r := extractHTTPRouteRoute(hr, tt.lookup)
 
 			if r.TLS != tt.wantTLS {
 				t.Errorf("TLS = %v, want %v", r.TLS, tt.wantTLS)
@@ -136,7 +289,7 @@ func TestExtractHTTPRouteRouteURLAnnotationOverride(t *testing.T) {
 		},
 	}
 
-	r := extractHTTPRouteRoute(hr)
+	r := extractHTTPRouteRoute(hr, nil)
 
 	if r.URL != "https://override.example.com" {
 		t.Errorf("URL = %q, want annotation override", r.URL)

--- a/internal/k8s/httproute_test.go
+++ b/internal/k8s/httproute_test.go
@@ -1,0 +1,144 @@
+package k8s
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func sectionName(s string) *gwv1.SectionName {
+	sn := gwv1.SectionName(s)
+	return &sn
+}
+
+func portNumber(p int32) *gwv1.PortNumber {
+	pn := gwv1.PortNumber(p)
+	return &pn
+}
+
+func TestExtractHTTPRouteRouteScheme(t *testing.T) {
+	tests := []struct {
+		name       string
+		parentRefs []gwv1.ParentReference
+		wantTLS    bool
+		wantURL    string
+	}{
+		{
+			name:       "no parentRef signal defaults to http",
+			parentRefs: []gwv1.ParentReference{{Name: "gateway"}},
+			wantTLS:    false,
+			wantURL:    "http://app.example.com",
+		},
+		{
+			name: "sectionName https",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gateway", SectionName: sectionName("https")},
+			},
+			wantTLS: true,
+			wantURL: "https://app.example.com",
+		},
+		{
+			name: "sectionName tls",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gateway", SectionName: sectionName("tls-listener")},
+			},
+			wantTLS: true,
+			wantURL: "https://app.example.com",
+		},
+		{
+			name: "sectionName websecure (traefik convention)",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gateway", SectionName: sectionName("websecure")},
+			},
+			wantTLS: true,
+			wantURL: "https://app.example.com",
+		},
+		{
+			name: "sectionName insecure stays http",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gateway", SectionName: sectionName("web-insecure")},
+			},
+			wantTLS: false,
+			wantURL: "http://app.example.com",
+		},
+		{
+			name: "sectionName web stays http",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gateway", SectionName: sectionName("web")},
+			},
+			wantTLS: false,
+			wantURL: "http://app.example.com",
+		},
+		{
+			name: "port 443 without sectionName",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gateway", Port: portNumber(443)},
+			},
+			wantTLS: true,
+			wantURL: "https://app.example.com",
+		},
+		{
+			name: "port 80 stays http",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gateway", Port: portNumber(80)},
+			},
+			wantTLS: false,
+			wantURL: "http://app.example.com",
+		},
+		{
+			name: "one of multiple parentRefs is https",
+			parentRefs: []gwv1.ParentReference{
+				{Name: "gateway", SectionName: sectionName("web")},
+				{Name: "gateway", SectionName: sectionName("websecure")},
+			},
+			wantTLS: true,
+			wantURL: "https://app.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hr := &gwv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: tt.parentRefs},
+					Hostnames:       []gwv1.Hostname{"app.example.com"},
+				},
+			}
+
+			r := extractHTTPRouteRoute(hr)
+
+			if r.TLS != tt.wantTLS {
+				t.Errorf("TLS = %v, want %v", r.TLS, tt.wantTLS)
+			}
+			if r.URL != tt.wantURL {
+				t.Errorf("URL = %q, want %q", r.URL, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestExtractHTTPRouteRouteURLAnnotationOverride(t *testing.T) {
+	hr := &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"routeboard.io/url": "https://override.example.com",
+			},
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			CommonRouteSpec: gwv1.CommonRouteSpec{
+				ParentRefs: []gwv1.ParentReference{{Name: "gateway"}},
+			},
+			Hostnames: []gwv1.Hostname{"app.example.com"},
+		},
+	}
+
+	r := extractHTTPRouteRoute(hr)
+
+	if r.URL != "https://override.example.com" {
+		t.Errorf("URL = %q, want annotation override", r.URL)
+	}
+}

--- a/internal/k8s/ingress_test.go
+++ b/internal/k8s/ingress_test.go
@@ -1,0 +1,53 @@
+package k8s
+
+import (
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExtractIngressRouteScheme(t *testing.T) {
+	tests := []struct {
+		name    string
+		tls     []networkingv1.IngressTLS
+		wantTLS bool
+		wantURL string
+	}{
+		{
+			name:    "no tls defaults to http",
+			tls:     nil,
+			wantTLS: false,
+			wantURL: "http://app.example.com",
+		},
+		{
+			name:    "tls covering host",
+			tls:     []networkingv1.IngressTLS{{Hosts: []string{"app.example.com"}}},
+			wantTLS: true,
+			wantURL: "https://app.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ingress := &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+				Spec: networkingv1.IngressSpec{
+					TLS: tt.tls,
+					Rules: []networkingv1.IngressRule{
+						{Host: "app.example.com"},
+					},
+				},
+			}
+
+			r := extractIngressRoute(ingress)
+
+			if r.TLS != tt.wantTLS {
+				t.Errorf("TLS = %v, want %v", r.TLS, tt.wantTLS)
+			}
+			if r.URL != tt.wantURL {
+				t.Errorf("URL = %q, want %q", r.URL, tt.wantURL)
+			}
+		})
+	}
+}

--- a/internal/k8s/watcher.go
+++ b/internal/k8s/watcher.go
@@ -32,6 +32,7 @@ type Watcher struct {
 
 	ingressInformer   cache.SharedIndexInformer
 	httprouteInformer cache.SharedIndexInformer
+	gatewayInformer   cache.SharedIndexInformer
 }
 
 func NewWatcher(cfg *config.Config, clients *Clients, store *store.Store) *Watcher {
@@ -60,6 +61,13 @@ func NewWatcher(cfg *config.Config, clients *Clients, store *store.Store) *Watch
 		if _, err := w.httprouteInformer.AddEventHandler(w.eventHandler(string(sourceHTTPRoute))); err != nil {
 			slog.Error("failed to add httproute event handler", "error", err)
 		}
+
+		// Watch Gateways so HTTPRoute URL schemes can be derived from the
+		// parent Gateway's listener TLS configuration.
+		w.gatewayInformer = w.gwFactory.Gateway().V1().Gateways().Informer()
+		if _, err := w.gatewayInformer.AddEventHandler(w.gatewayEventHandler()); err != nil {
+			slog.Error("failed to add gateway event handler", "error", err)
+		}
 	}
 
 	return w
@@ -68,6 +76,10 @@ func NewWatcher(cfg *config.Config, clients *Clients, store *store.Store) *Watch
 const (
 	sourceIngress   = "Ingress"
 	sourceHTTPRoute = "HTTPRoute"
+
+	// gatewaySyncTimeout bounds the wait for the Gateway informer cache at
+	// startup so missing RBAC does not block the watcher indefinitely.
+	gatewaySyncTimeout = 30 * time.Second
 )
 
 func (w *Watcher) eventHandler(source string) cache.ResourceEventHandlerFuncs {
@@ -94,6 +106,43 @@ func (w *Watcher) eventHandler(source string) cache.ResourceEventHandlerFuncs {
 	}
 }
 
+// gatewayEventHandler re-enqueues all known HTTPRoutes whenever a Gateway
+// changes, since listener TLS config determines the routes' URL schemes.
+func (w *Watcher) gatewayEventHandler() cache.ResourceEventHandlerFuncs {
+	requeueAll := func(interface{}) {
+		if w.httprouteInformer == nil {
+			return
+		}
+		for _, key := range w.httprouteInformer.GetStore().ListKeys() {
+			w.queue.Add(sourceHTTPRoute + ":" + key)
+		}
+	}
+
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    requeueAll,
+		UpdateFunc: func(_, newObj interface{}) { requeueAll(newObj) },
+		DeleteFunc: requeueAll,
+	}
+}
+
+// lookupGateway resolves a Gateway from the informer cache. It returns nil
+// when the cache has no such Gateway (e.g. not synced yet or missing RBAC),
+// letting callers fall back to heuristics.
+func (w *Watcher) lookupGateway(namespace, name string) *gwv1.Gateway {
+	if w.gatewayInformer == nil {
+		return nil
+	}
+	obj, exists, err := w.gatewayInformer.GetStore().GetByKey(namespace + "/" + name)
+	if err != nil || !exists {
+		return nil
+	}
+	gw, ok := obj.(*gwv1.Gateway)
+	if !ok {
+		return nil
+	}
+	return gw
+}
+
 func (w *Watcher) Run(ctx context.Context) error {
 	defer runtime.HandleCrash()
 	defer w.queue.ShutDown()
@@ -116,6 +165,17 @@ func (w *Watcher) Run(ctx context.Context) error {
 	}
 	if !cache.WaitForCacheSync(ctx.Done(), syncs...) {
 		return fmt.Errorf("timed out waiting for informer caches to sync")
+	}
+
+	// Wait for the Gateway cache with a bounded timeout so clusters without
+	// gateways list/watch RBAC (e.g. existing installs) degrade gracefully to
+	// the parentRef heuristic instead of blocking startup or crashing.
+	if w.gatewayInformer != nil {
+		gwCtx, cancel := context.WithTimeout(ctx, gatewaySyncTimeout)
+		if !cache.WaitForCacheSync(gwCtx.Done(), w.gatewayInformer.HasSynced) {
+			slog.Warn("gateway informer cache did not sync; falling back to parentRef heuristics for URL schemes (check RBAC for gateways get/list/watch)")
+		}
+		cancel()
 	}
 
 	slog.Info("informer caches synced, starting workers")
@@ -217,7 +277,7 @@ func (w *Watcher) syncHTTPRoute(key string) error {
 		return fmt.Errorf("unexpected type for httproute %s", key)
 	}
 
-	route := extractHTTPRouteRoute(hr)
+	route := extractHTTPRouteRoute(hr, w.lookupGateway)
 	w.store.Set(route)
 	return nil
 }


### PR DESCRIPTION
Fixes #4

## Problem

Auto-discovered HTTPRoutes render `http://` links even when the endpoint is actually served over HTTPS, so links on the board are broken.

## Root cause

HTTPRoute objects carry no TLS configuration themselves — TLS termination lives on the parent Gateway's listeners, which routeboard did not watch. `extractHTTPRouteRoute` (internal/k8s/httproute.go) guessed the scheme purely from parentRef `sectionName` text (only `https`/`tls` substrings), so routes attaching by `port: 443`, via Traefik's conventional `websecure` listener, or via a plain gateway ref all rendered `http://`.

The Ingress converter is unaffected: it correctly infers HTTPS from `spec.tls` (regression tests added to lock that in).

## Solution

**Gateway listener resolution (the proper fix).** A Gateways informer is added from the existing Gateway API informer factory (`gwFactory`), wired through the watcher like the HTTPRoute informer. When converting an HTTPRoute, each parentRef is resolved to its Gateway (namespace defaults to the route's namespace; only group `gateway.networking.k8s.io` / kind `Gateway`, with empty group/kind defaulting to Gateway) and the scheme is decided from the actual listeners:

- `sectionName` set → match the listener by name
- else `port` set → match listeners by port
- else → consider all listeners, preferring HTTPS when mixed
- a matched listener implies `https` when its protocol is `HTTPS` or `TLS` and its hostname (if set) is compatible with the route's hostnames (exact or single-wildcard match — deliberately simple)

Gateway add/update/delete events re-enqueue all known HTTPRoutes so schemes stay current when listeners change.

**Heuristic as documented fallback.** When the Gateway is not found in the cache (informer not synced yet, missing RBAC on existing installs, cross-namespace ref not readable), conversion falls back to the parentRef heuristic — port 443, or sectionName containing `https`/`tls`/`secure` (but not `insecure`, covering Traefik's `websecure`) — and logs at debug level. The `routeboard.io/url` annotation remains the explicit per-route override.

**Graceful degradation, no crash.** Startup waits for the Gateway cache with a bounded 30s timeout; if it never syncs (e.g. RBAC forbidden), the watcher logs a warning and proceeds with the heuristic — client-go reflector errors are logged and retried, so the app does not crash and route discovery is unaffected.

## RBAC

- Helm chart: `deploy/helm/routeboard/templates/clusterrole.yaml` now grants `get`/`list`/`watch` on `gateways` in `gateway.networking.k8s.io` alongside `httproutes` (the `rbac.create` guard is kept).
- **Call-out for existing non-Helm installs:** manually managed ClusterRoles need the same `gateways` verbs added; until then routeboard falls back to the parentRef heuristic (with a startup warning) instead of failing.

## Testing

- `TestExtractHTTPRouteRouteGatewayListenerTLS` (10 table-driven cases): sectionName → HTTPS listener, sectionName → HTTP listener (even when named `websecure`), port match to HTTPS/HTTP listeners, no sectionName/port with mixed vs HTTP-only listeners, `TLS` protocol listeners, cross-namespace parentRef, wildcard-hostname compatible and incompatible listeners.
- `TestExtractHTTPRouteRouteFallbackHeuristic` (9 cases): Gateway missing from cache falls back to port 443 → https, `websecure` → https, `web`/`insecure`/port 80 → http; plus nil-lookup and multi-parentRef cases.
- `TestExtractHTTPRouteRouteURLAnnotationOverride` and `TestExtractIngressRouteScheme` guard the annotation escape hatch and the Ingress path.
- Tests written first (TDD); the fake gateway lookup mirrors the informer-cache resolution used by the watcher.
- `go build ./... && go vet ./...` clean; `go test -race ./internal/k8s/ ./internal/model/` passes (31 tests); full `go test ./...` passes. The only `-race` failure on this branch is the pre-existing SSE broker race in `internal/server/sse.go`, fixed separately in #15 and untouched here.
- `helm lint deploy/helm/routeboard` passes.