### PR TITLE
fix: data race on clients map length read in SSEBroker

### DIFF
--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -44,17 +44,19 @@ func (b *SSEBroker) subscribe() chan []byte {
 	ch := make(chan []byte, 16)
 	b.mu.Lock()
 	b.clients[ch] = struct{}{}
+	total := len(b.clients)
 	b.mu.Unlock()
-	slog.Debug("SSE client connected", "total", len(b.clients))
+	slog.Debug("SSE client connected", "total", total)
 	return ch
 }
 
 func (b *SSEBroker) unsubscribe(ch chan []byte) {
 	b.mu.Lock()
 	delete(b.clients, ch)
+	total := len(b.clients)
 	b.mu.Unlock()
 	close(ch)
-	slog.Debug("SSE client disconnected", "total", len(b.clients))
+	slog.Debug("SSE client disconnected", "total", total)
 }
 
 func (b *SSEBroker) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Problem

`go test -race` fails intermittently on `TestSSEBrokerMultipleClients` (currently failing CI on unrelated PRs #12 and #14):

```
WARNING: DATA RACE
Write at ... by goroutine 28: runtime.mapdelete_fast64() ... sse.go:54
Previous read at ... by goroutine 34: (*SSEBroker).unsubscribe() ... sse.go:57
```

Both `subscribe` and `unsubscribe` log `len(b.clients)` **after** `b.mu.Unlock()`, so the unlocked map read races with another goroutine's `delete`/insert. It only trips when two SSE clients connect/disconnect concurrently, which is why CI fails flakily by timing.

## Solution

Capture the count while the lock is held and log the captured value. Two-line change, no behavior change.

## Testing

- `go test -race -count=200 -run TestSSEBroker ./internal/server` — 400/400 pass (previously flaky)
- `go test -race ./...` and `go vet ./...` — clean

Unblocks CI on #12 and #14, which fail on this pre-existing race, not on their own changes.