### PR TITLE
feat: static routes + standalone (no-k8s) mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,52 @@ jobs:
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           helm push /tmp/helm-pkg/routeboard-${VERSION}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/helm
+
+  binaries:
+    name: Build & Upload Release Binaries
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build frontend
+        run: cd web && bun install && bun run build
+
+      - name: Embed frontend
+        run: |
+          rm -rf internal/server/dist
+          cp -r web/dist internal/server/dist
+
+      - name: Build binaries
+        run: |
+          VERSION=${GITHUB_REF_NAME}
+          mkdir -p dist
+          for arch in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH=$arch \
+              go build -trimpath -ldflags "-X main.version=${VERSION}" \
+              -o dist/routeboard ./cmd/routeboard
+            tar -C dist -czf dist/routeboard-linux-${arch}.tar.gz routeboard
+            rm dist/routeboard
+          done
+          (cd dist && sha256sum routeboard-linux-*.tar.gz > checksums.txt)
+
+      - name: Create GitHub release with assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/routeboard-linux-amd64.tar.gz
+            dist/routeboard-linux-arm64.tar.gz
+            dist/checksums.txt
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ All configuration is via environment variables. Everything has sensible defaults
 | `ROUTEBOARD_HEALTH_TIMEOUT` | `5s` | Health check timeout |
 | `ROUTEBOARD_LOG_LEVEL` | `info` | Log level (debug/info/warn/error) |
 | `ROUTEBOARD_LOG_FORMAT` | `text` | Log format (text/json) |
+| `ROUTEBOARD_STATIC_ROUTES` | `""` | Path to a YAML file of static routes served alongside (or instead of) discovered ones |
+| `ROUTEBOARD_KUBE_ENABLED` | `true` | Set `false` to run without Kubernetes (static routes only) |
 
 ## Annotations
 
@@ -115,6 +117,26 @@ metadata:
     routeboard.io/url: "https://custom.url"      # Override computed URL
     routeboard.io/health: "false"                # Exclude from health checks (route stays listed)
 ```
+
+## Static routes (no Kubernetes required)
+
+RouteBoard can serve endpoints that don't live in a cluster — bare VMs,
+appliances, homelab boxes. Point `ROUTEBOARD_STATIC_ROUTES` at a YAML file:
+
+```yaml
+routes:
+  - name: grafana                  # required, unique
+    url: http://192.168.10.30:3000 # required
+    title: Grafana                 # optional (default: name)
+    description: Metrics           # optional
+    group: monitoring              # optional (default: "static")
+    icon: si:grafana               # optional
+    order: 1                       # optional
+    health: true                   # optional, default true
+```
+
+Set `ROUTEBOARD_KUBE_ENABLED=false` to run fully standalone. The file is
+read once at startup; restart the service after editing it.
 
 ## Architecture
 

--- a/cmd/routeboard/main.go
+++ b/cmd/routeboard/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dhia/routeboard/internal/health"
 	"github.com/dhia/routeboard/internal/k8s"
 	"github.com/dhia/routeboard/internal/server"
+	"github.com/dhia/routeboard/internal/static"
 	"github.com/dhia/routeboard/internal/store"
 	"github.com/dhia/routeboard/internal/webhook"
 )
@@ -38,20 +39,42 @@ func main() {
 
 	routeStore := store.New(listeners...)
 
-	clients, err := k8s.NewClients(cfg.Kubeconfig)
-	if err != nil {
-		slog.Error("failed to create kubernetes clients", "error", err)
+	if !cfg.KubeEnabled && cfg.StaticRoutesPath == "" {
+		slog.Error("nothing to serve: kubernetes disabled and no static routes file",
+			"hint", "set ROUTEBOARD_STATIC_ROUTES or ROUTEBOARD_KUBE_ENABLED=true")
 		os.Exit(1)
 	}
 
-	watcher := k8s.NewWatcher(cfg, clients, routeStore)
-
-	go func() {
-		if err := watcher.Run(ctx); err != nil {
-			slog.Error("watcher error", "error", err)
-			cancel()
+	if cfg.StaticRoutesPath != "" {
+		staticRoutes, err := static.Load(cfg.StaticRoutesPath)
+		if err != nil {
+			slog.Error("failed to load static routes", "path", cfg.StaticRoutesPath, "error", err)
+			os.Exit(1)
 		}
-	}()
+		for _, r := range staticRoutes {
+			routeStore.Set(r)
+		}
+		slog.Info("loaded static routes", "count", len(staticRoutes), "path", cfg.StaticRoutesPath)
+	}
+
+	if cfg.KubeEnabled {
+		clients, err := k8s.NewClients(cfg.Kubeconfig)
+		if err != nil {
+			slog.Error("failed to create kubernetes clients", "error", err)
+			os.Exit(1)
+		}
+
+		watcher := k8s.NewWatcher(cfg, clients, routeStore)
+
+		go func() {
+			if err := watcher.Run(ctx); err != nil {
+				slog.Error("watcher error", "error", err)
+				cancel()
+			}
+		}()
+	} else {
+		slog.Info("kubernetes watching disabled")
+	}
 
 	if cfg.HealthEnabled {
 		checker := health.NewChecker(cfg, routeStore)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dhia/routeboard
 go 1.25.0
 
 require (
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
@@ -40,7 +41,6 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	WatchIngress   bool
 	WatchHTTPRoute bool
 
+	KubeEnabled      bool
+	StaticRoutesPath string
+
 	Title     string
 	LogLevel  string
 	LogFormat string // text, json
@@ -43,17 +46,19 @@ func Load() *Config {
 		NamespaceDenylist: envSlice("ROUTEBOARD_NAMESPACE_DENYLIST", []string{
 			"kube-system", "kube-public", "kube-node-lease",
 		}),
-		LabelSelector:  envStr("ROUTEBOARD_LABEL_SELECTOR", ""),
-		WatchIngress:   envBool("ROUTEBOARD_WATCH_INGRESS", true),
-		WatchHTTPRoute: envBool("ROUTEBOARD_WATCH_HTTPROUTE", true),
-		Title:          envStr("ROUTEBOARD_TITLE", "RouteBoard"),
-		LogLevel:       envStr("ROUTEBOARD_LOG_LEVEL", "info"),
-		LogFormat:      envStr("ROUTEBOARD_LOG_FORMAT", "text"),
-		HealthEnabled:  envBool("ROUTEBOARD_HEALTH_ENABLED", true),
-		HealthInterval: envDuration("ROUTEBOARD_HEALTH_INTERVAL", 30*time.Second),
-		HealthTimeout:  envDuration("ROUTEBOARD_HEALTH_TIMEOUT", 5*time.Second),
-		WebhookURL:     envStr("ROUTEBOARD_WEBHOOK_URL", ""),
-		WebhookFormat:  envStr("ROUTEBOARD_WEBHOOK_FORMAT", "json"),
+		LabelSelector:    envStr("ROUTEBOARD_LABEL_SELECTOR", ""),
+		WatchIngress:     envBool("ROUTEBOARD_WATCH_INGRESS", true),
+		WatchHTTPRoute:   envBool("ROUTEBOARD_WATCH_HTTPROUTE", true),
+		KubeEnabled:      envBool("ROUTEBOARD_KUBE_ENABLED", true),
+		StaticRoutesPath: envStr("ROUTEBOARD_STATIC_ROUTES", ""),
+		Title:            envStr("ROUTEBOARD_TITLE", "RouteBoard"),
+		LogLevel:         envStr("ROUTEBOARD_LOG_LEVEL", "info"),
+		LogFormat:        envStr("ROUTEBOARD_LOG_FORMAT", "text"),
+		HealthEnabled:    envBool("ROUTEBOARD_HEALTH_ENABLED", true),
+		HealthInterval:   envDuration("ROUTEBOARD_HEALTH_INTERVAL", 30*time.Second),
+		HealthTimeout:    envDuration("ROUTEBOARD_HEALTH_TIMEOUT", 5*time.Second),
+		WebhookURL:       envStr("ROUTEBOARD_WEBHOOK_URL", ""),
+		WebhookFormat:    envStr("ROUTEBOARD_WEBHOOK_FORMAT", "json"),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,3 +26,26 @@ func TestLoadLogFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadDefaults(t *testing.T) {
+	cfg := Load()
+	if cfg.StaticRoutesPath != "" {
+		t.Errorf("StaticRoutesPath = %q, want empty default", cfg.StaticRoutesPath)
+	}
+	if !cfg.KubeEnabled {
+		t.Error("KubeEnabled = false, want true by default")
+	}
+}
+
+func TestLoadStaticAndKubeEnv(t *testing.T) {
+	t.Setenv("ROUTEBOARD_STATIC_ROUTES", "/etc/routeboard/routes.yml")
+	t.Setenv("ROUTEBOARD_KUBE_ENABLED", "false")
+
+	cfg := Load()
+	if cfg.StaticRoutesPath != "/etc/routeboard/routes.yml" {
+		t.Errorf("StaticRoutesPath = %q, want %q", cfg.StaticRoutesPath, "/etc/routeboard/routes.yml")
+	}
+	if cfg.KubeEnabled {
+		t.Error("KubeEnabled = true, want false")
+	}
+}

--- a/internal/model/route.go
+++ b/internal/model/route.go
@@ -7,6 +7,7 @@ type RouteSource string
 const (
 	SourceIngress   RouteSource = "Ingress"
 	SourceHTTPRoute RouteSource = "HTTPRoute"
+	SourceStatic    RouteSource = "Static"
 )
 
 type Route struct {

--- a/internal/static/static.go
+++ b/internal/static/static.go
@@ -1,0 +1,93 @@
+// Package static loads dashboard routes from a YAML file, for endpoints
+// that don't live behind a Kubernetes Ingress/HTTPRoute (bare VMs, LXCs,
+// appliances).
+package static
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/dhia/routeboard/internal/model"
+)
+
+type entry struct {
+	Name        string `yaml:"name"`
+	URL         string `yaml:"url"`
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
+	Group       string `yaml:"group"`
+	Icon        string `yaml:"icon"`
+	Order       int    `yaml:"order"`
+	Health      *bool  `yaml:"health"`
+}
+
+type file struct {
+	Routes []entry `yaml:"routes"`
+}
+
+// Load reads and validates a static routes file. Any invalid entry is a
+// hard error: the caller is expected to treat it as fatal at startup.
+func Load(path string) ([]*model.Route, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read static routes: %w", err)
+	}
+	var f file
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse static routes: %w", err)
+	}
+	if len(f.Routes) == 0 {
+		return nil, fmt.Errorf("static routes file %s contains no routes", path)
+	}
+
+	seen := make(map[string]struct{}, len(f.Routes))
+	routes := make([]*model.Route, 0, len(f.Routes))
+	now := time.Now()
+
+	for i, e := range f.Routes {
+		if e.Name == "" {
+			return nil, fmt.Errorf("static route #%d: name is required", i+1)
+		}
+		if _, dup := seen[e.Name]; dup {
+			return nil, fmt.Errorf("static route %q: duplicate name", e.Name)
+		}
+		seen[e.Name] = struct{}{}
+		if e.URL == "" {
+			return nil, fmt.Errorf("static route %q: url is required", e.Name)
+		}
+		if u, err := url.Parse(e.URL); err != nil || u.Scheme == "" || u.Host == "" {
+			return nil, fmt.Errorf("static route %q: invalid url %q", e.Name, e.URL)
+		}
+
+		title := e.Title
+		if title == "" {
+			title = e.Name
+		}
+		group := e.Group
+		if group == "" {
+			group = "static"
+		}
+
+		routes = append(routes, &model.Route{
+			ID:             "static/" + e.Name,
+			Name:           e.Name,
+			Namespace:      "static",
+			Source:         model.SourceStatic,
+			URL:            e.URL,
+			Title:          title,
+			Description:    e.Description,
+			Icon:           e.Icon,
+			Group:          group,
+			Order:          e.Order,
+			Health:         model.HealthUnknown,
+			HealthDisabled: e.Health != nil && !*e.Health,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		})
+	}
+	return routes, nil
+}

--- a/internal/static/static_test.go
+++ b/internal/static/static_test.go
@@ -1,0 +1,113 @@
+package static
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dhia/routeboard/internal/model"
+)
+
+func writeFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "routes.yml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadValidFile(t *testing.T) {
+	path := writeFile(t, `
+routes:
+  - name: grafana
+    url: http://192.168.10.30:3000
+    title: Grafana
+    description: Metrics & dashboards
+    group: monitoring
+    icon: si:grafana
+    order: 1
+  - name: proxmox
+    url: https://192.168.1.10:8006
+    health: false
+`)
+	routes, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(routes) != 2 {
+		t.Fatalf("len(routes) = %d, want 2", len(routes))
+	}
+
+	g := routes[0]
+	if g.ID != "static/grafana" {
+		t.Errorf("ID = %q, want %q", g.ID, "static/grafana")
+	}
+	if g.Source != model.SourceStatic {
+		t.Errorf("Source = %q, want %q", g.Source, model.SourceStatic)
+	}
+	if g.Namespace != "static" {
+		t.Errorf("Namespace = %q, want %q", g.Namespace, "static")
+	}
+	if g.Title != "Grafana" || g.Group != "monitoring" || g.Icon != "si:grafana" || g.Order != 1 {
+		t.Errorf("unexpected fields: %+v", g)
+	}
+	if g.Description != "Metrics & dashboards" {
+		t.Errorf("Description = %q", g.Description)
+	}
+	if g.HealthDisabled {
+		t.Error("HealthDisabled = true, want false (default)")
+	}
+	if g.Health != model.HealthUnknown {
+		t.Errorf("Health = %q, want %q", g.Health, model.HealthUnknown)
+	}
+	if g.CreatedAt.IsZero() || g.UpdatedAt.IsZero() {
+		t.Error("CreatedAt/UpdatedAt not set")
+	}
+
+	p := routes[1]
+	if p.Title != "proxmox" {
+		t.Errorf("Title = %q, want name fallback %q", p.Title, "proxmox")
+	}
+	if p.Group != "static" {
+		t.Errorf("Group = %q, want default %q", p.Group, "static")
+	}
+	if !p.HealthDisabled {
+		t.Error("HealthDisabled = false, want true (health: false)")
+	}
+}
+
+func TestLoadErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{"missing name", "routes:\n  - url: http://x\n", "name is required"},
+		{"missing url", "routes:\n  - name: a\n", "url is required"},
+		{"duplicate name", "routes:\n  - name: a\n    url: http://x\n  - name: a\n    url: http://y\n", "duplicate name"},
+		{"invalid url", "routes:\n  - name: a\n    url: '://nope'\n", "invalid url"},
+		{"url without scheme", "routes:\n  - name: a\n    url: 192.168.1.10:8006\n", "invalid url"},
+		{"empty file", "routes: []\n", "no routes"},
+		{"malformed yaml", "routes: [oops\n", "parse static routes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Load(writeFile(t, tt.content))
+			if err == nil {
+				t.Fatal("Load() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadFileNotFound(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), "missing.yml"))
+	if err == nil {
+		t.Fatal("Load() error = nil, want error")
+	}
+}

--- a/web/src/components/RouteCard.tsx
+++ b/web/src/components/RouteCard.tsx
@@ -203,7 +203,7 @@ function ResponseTimeBadge({ ms }: { ms?: number }) {
 	);
 }
 
-function SourceBadge({ source }: { source: "Ingress" | "HTTPRoute" }) {
+function SourceBadge({ source }: { source: "Ingress" | "HTTPRoute" | "Static" }) {
 	const isIngress = source === "Ingress";
 	return (
 		<span

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -2,7 +2,7 @@ export interface Route {
 	id: string;
 	name: string;
 	namespace: string;
-	source: "Ingress" | "HTTPRoute";
+	source: "Ingress" | "HTTPRoute" | "Static";
 	url: string;
 	hosts: string[];
 	paths: string[];


### PR DESCRIPTION
Adds `ROUTEBOARD_STATIC_ROUTES` (YAML endpoint list, fail-fast validation, served as `Source: Static`) and `ROUTEBOARD_KUBE_ENABLED=false` standalone mode — health checks, SSE, search and grouping work on static routes unchanged. The release workflow now also ships linux amd64/arm64 binary tarballs + checksums.txt on version tags.

Motivation: reuse RouteBoard as a homelab (non-Kubernetes) start page.

Note: the CI binaries job intentionally mirrors the Makefile build recipe inline (needs GOARCH/GITHUB_REF_NAME); keep the two in sync when the build changes.